### PR TITLE
Ack handling

### DIFF
--- a/src/net/BUILD.gn
+++ b/src/net/BUILD.gn
@@ -1412,19 +1412,6 @@ component("net") {
       "quic/platform/impl/quic_url_impl.h",
       "quic/platform/impl/quic_url_utils_impl.cc",
       "quic/platform/impl/quic_url_utils_impl.h",
-      "quic/quartc/quartc_clock_interface.h",
-      "quic/quartc/quartc_factory.cc",
-      "quic/quartc/quartc_factory.h",
-      "quic/quartc/quartc_factory_interface.h",
-      "quic/quartc/quartc_packet_writer.cc",
-      "quic/quartc/quartc_packet_writer.h",
-      "quic/quartc/quartc_session.cc",
-      "quic/quartc/quartc_session.h",
-      "quic/quartc/quartc_session_interface.h",
-      "quic/quartc/quartc_stream.cc",
-      "quic/quartc/quartc_stream.h",
-      "quic/quartc/quartc_stream_interface.h",
-      "quic/quartc/quartc_task_runner_interface.h",
       "reporting/reporting_browsing_data_remover.cc",
       "reporting/reporting_browsing_data_remover.h",
       "reporting/reporting_cache.cc",
@@ -2920,6 +2907,39 @@ if (is_linux) {
     ]
   }
 
+  source_set("epoll_multipath_quic_tools") {
+    sources = [
+      "tools/quic/platform/impl/quic_epoll_clock.cc",
+      "tools/quic/platform/impl/quic_epoll_clock.h",
+      "tools/quic/platform/impl/quic_socket_utils.cc",
+      "tools/quic/platform/impl/quic_socket_utils.h",
+      "tools/quic/quic_multipath_client.cc",
+      "tools/quic/quic_multipath_client.h",
+      "tools/quic/quic_multipath_server.cc",
+      "tools/quic/quic_multipath_server.h",
+      "tools/quic/quic_default_packet_writer.cc",
+      "tools/quic/quic_default_packet_writer.h",
+      "tools/quic/quic_epoll_alarm_factory.cc",
+      "tools/quic/quic_epoll_alarm_factory.h",
+      "tools/quic/quic_epoll_connection_helper.cc",
+      "tools/quic/quic_epoll_connection_helper.h",
+      "tools/quic/quic_packet_reader.cc",
+      "tools/quic/quic_packet_reader.h",
+      "tools/quic/quic_packet_writer_wrapper.cc",
+      "tools/quic/quic_packet_writer_wrapper.h",
+    ]
+    deps = [
+      ":epoll_server",
+      ":net",
+      ":simple_multipath_quic_tools",
+      "//base",
+      "//base/third_party/dynamic_annotations",
+      "//crypto",
+      "//third_party/boringssl",
+      "//url",
+    ]
+  }
+
   source_set("epoll_quic_tools") {
     sources = [
       "tools/quic/platform/impl/quic_epoll_clock.cc",
@@ -2992,10 +3012,10 @@ if (is_linux) {
       "tools/quic/quic_multipath_client_bin.cc",
     ]
     deps = [
-      ":epoll_quic_tools",
+      ":epoll_multipath_quic_tools",
       ":epoll_server",
       ":net",
-      ":simple_quic_tools",
+      ":simple_multipath_quic_tools",
       "//base",
       "//build/config:exe_and_shlib_deps",
       "//third_party/boringssl",
@@ -3007,10 +3027,10 @@ if (is_linux) {
       "tools/quic/quic_multipath_server_bin.cc",
     ]
     deps = [
-      ":epoll_quic_tools",
+      ":epoll_multipath_quic_tools",
       ":epoll_server",
       ":net",
-      ":simple_quic_tools",
+      ":simple_multipath_quic_tools",
       "//base",
       "//build/config:exe_and_shlib_deps",
       "//third_party/boringssl",
@@ -3059,6 +3079,52 @@ if (is_android || is_linux) {
       "//build/config:exe_and_shlib_deps",
     ]
   }
+}
+
+source_set("simple_multipath_quic_tools") {
+  sources = [
+    "tools/quic/chlo_extractor.cc",
+    "tools/quic/chlo_extractor.h",
+    "tools/quic/quic_client_base.cc",
+    "tools/quic/quic_client_base.h",
+    "tools/quic/quic_client_session.cc",
+    "tools/quic/quic_client_session.h",
+    "tools/quic/quic_dispatcher.cc",
+    "tools/quic/quic_dispatcher.h",
+    "tools/quic/quic_http_response_cache.cc",
+    "tools/quic/quic_http_response_cache.h",
+    "tools/quic/quic_per_connection_packet_writer.cc",
+    "tools/quic/quic_per_connection_packet_writer.h",
+    "tools/quic/quic_process_packet_interface.h",
+    "tools/quic/quic_simple_crypto_server_stream_helper.cc",
+    "tools/quic/quic_simple_crypto_server_stream_helper.h",
+    "tools/quic/quic_simple_dispatcher.cc",
+    "tools/quic/quic_simple_dispatcher.h",
+    "tools/quic/quic_simple_per_connection_packet_writer.cc",
+    "tools/quic/quic_simple_per_connection_packet_writer.h",
+    "tools/quic/quic_simple_server_packet_writer.cc",
+    "tools/quic/quic_simple_server_packet_writer.h",
+    "tools/quic/quic_simple_server_session.cc",
+    "tools/quic/quic_simple_server_session.h",
+    "tools/quic/quic_simple_server_stream.cc",
+    "tools/quic/quic_simple_server_stream.h",
+    "tools/quic/quic_spdy_client_stream.cc",
+    "tools/quic/quic_spdy_client_stream.h",
+    "tools/quic/quic_spdy_server_stream_base.cc",
+    "tools/quic/quic_spdy_server_stream_base.h",
+    "tools/quic/quic_time_wait_list_manager.cc",
+    "tools/quic/quic_time_wait_list_manager.h",
+    "tools/quic/stateless_rejector.cc",
+    "tools/quic/stateless_rejector.h",
+    "tools/quic/synchronous_host_resolver.cc",
+    "tools/quic/synchronous_host_resolver.h",
+  ]
+  deps = [
+    ":net",
+    "//base",
+    "//base/third_party/dynamic_annotations",
+    "//url",
+  ]
 }
 
 source_set("simple_quic_tools") {

--- a/src/net/quic/chromium/quic_chromium_client_session.h
+++ b/src/net/quic/chromium/quic_chromium_client_session.h
@@ -316,7 +316,7 @@ class NET_EXPORT_PRIVATE QuicChromiumClientSession
   void SendRstStream(QuicStreamId id,
                      QuicRstStreamErrorCode error,
                      QuicStreamOffset bytes_written) override;
-  void OnCryptoHandshakeEvent(CryptoHandshakeEvent event) override;
+  void OnCryptoHandshakeEvent(QuicConnection* connection, CryptoHandshakeEvent event) override;
   void OnCryptoHandshakeMessageSent(
       const CryptoHandshakeMessage& message) override;
   void OnCryptoHandshakeMessageReceived(
@@ -325,7 +325,7 @@ class NET_EXPORT_PRIVATE QuicChromiumClientSession
   void OnRstStream(const QuicRstStreamFrame& frame) override;
 
   // QuicClientSessionBase methods:
-  void OnConfigNegotiated() override;
+  void OnConfigNegotiated(QuicConnection *connection) override;
   void OnProofValid(const QuicCryptoClientConfig::CachedState& cached) override;
   void OnProofVerifyDetailsAvailable(
       const ProofVerifyDetails& verify_details) override;

--- a/src/net/quic/chromium/quic_connection_logger.cc
+++ b/src/net/quic/chromium/quic_connection_logger.cc
@@ -321,7 +321,8 @@ QuicConnectionLogger::~QuicConnectionLogger() {
   UMA_HISTOGRAM_COUNTS("Net.QuicSession.BlockedFrames.Sent",
                        num_blocked_frames_sent_);
 
-  const QuicConnectionStats& stats = session_->connection()->GetStats();
+  //TODO combine stats from all subflows
+  const QuicConnectionStats& stats = session_->InitialConnection()->GetStats();
   UMA_HISTOGRAM_TIMES("Net.QuicSession.MinRTT",
                       base::TimeDelta::FromMicroseconds(stats.min_rtt_us));
   UMA_HISTOGRAM_TIMES("Net.QuicSession.SmoothedRTT",

--- a/src/net/quic/core/quic_client_promised_info.cc
+++ b/src/net/quic/core/quic_client_promised_info.cc
@@ -28,10 +28,10 @@ void QuicClientPromisedInfo::CleanupAlarm::OnAlarm() {
 }
 
 void QuicClientPromisedInfo::Init() {
-  cleanup_alarm_.reset(session_->connection()->alarm_factory()->CreateAlarm(
+  cleanup_alarm_.reset(session_->AnyConnection()->alarm_factory()->CreateAlarm(
       new QuicClientPromisedInfo::CleanupAlarm(this)));
   cleanup_alarm_->Set(
-      session_->connection()->helper()->GetClock()->ApproximateNow() +
+      session_->AnyConnection()->helper()->GetClock()->ApproximateNow() +
       QuicTime::Delta::FromSeconds(kPushPromiseTimeoutSecs));
 }
 

--- a/src/net/quic/core/quic_client_session_base.cc
+++ b/src/net/quic/core/quic_client_session_base.cc
@@ -27,15 +27,15 @@ QuicClientSessionBase::~QuicClientSessionBase() {
     QUIC_DVLOG(1) << "erase stream " << it.first << " url " << it.second->url();
     push_promise_index_->promised_by_url()->erase(it.second->url());
   }
-  delete connection();
+  delete InitialConnection();
 }
 
-void QuicClientSessionBase::OnConfigNegotiated() {
-  QuicSpdySession::OnConfigNegotiated();
+void QuicClientSessionBase::OnConfigNegotiated(QuicConnection *connection) {
+  QuicSpdySession::OnConfigNegotiated(connection);
 }
 
-void QuicClientSessionBase::OnCryptoHandshakeEvent(CryptoHandshakeEvent event) {
-  QuicSpdySession::OnCryptoHandshakeEvent(event);
+void QuicClientSessionBase::OnCryptoHandshakeEvent(QuicConnection* connection, CryptoHandshakeEvent event) {
+  QuicSpdySession::OnCryptoHandshakeEvent(connection, event);
 }
 
 void QuicClientSessionBase::OnInitialHeadersComplete(
@@ -60,7 +60,7 @@ void QuicClientSessionBase::OnPromiseHeaderList(
     const QuicHeaderList& header_list) {
   if (promised_stream_id != kInvalidStreamId &&
       promised_stream_id <= largest_promised_stream_id_) {
-    connection()->CloseConnection(
+    CloseConnection(
         QUIC_INVALID_STREAM_ID,
         "Received push stream id lesser or equal to the"
         " last accepted before",

--- a/src/net/quic/core/quic_client_session_base.h
+++ b/src/net/quic/core/quic_client_session_base.h
@@ -44,10 +44,10 @@ class QUIC_EXPORT_PRIVATE QuicClientSessionBase
 
   ~QuicClientSessionBase() override;
 
-  void OnConfigNegotiated() override;
+  void OnConfigNegotiated(QuicConnection *connection) override;
 
   // Override base class to set FEC policy before any data is sent by client.
-  void OnCryptoHandshakeEvent(CryptoHandshakeEvent event) override;
+  void OnCryptoHandshakeEvent(QuicConnection* connection, CryptoHandshakeEvent event) override;
 
   // Called by |headers_stream_| when push promise headers have been
   // completely received.

--- a/src/net/quic/core/quic_connection.cc
+++ b/src/net/quic/core/quic_connection.cc
@@ -1156,7 +1156,11 @@ void QuicConnection::ClearLastFrames() {
 
 const QuicFrames QuicConnection::GetUpdatedAckFrames() {
   //TODO(cyrill) call visitor and collect all updated ack frames.
-  return received_packet_manager_.GetUpdatedAckFrame(clock_->ApproximateNow());
+  if(visitor_) {
+    return visitor_->GetUpdatedAckFrames(subflow_id, clock_ApproximateNow());
+  }
+  return nullptr;
+  //received_packet_manager_.GetUpdatedAckFrame(clock_->ApproximateNow());
 }
 
 void QuicConnection::PopulateStopWaitingFrame(

--- a/src/net/quic/core/quic_connection.cc
+++ b/src/net/quic/core/quic_connection.cc
@@ -182,7 +182,8 @@ QuicConnection::QuicConnection(QuicConnectionId connection_id,
                                const QuicVersionVector& supported_versions,
                                QuicFramer *framer,
                                bool owns_framer,
-                               bool do_not_perform_handshake)
+                               bool do_not_perform_handshake,
+                               QuicSubflowId subflow_id)
     : framer_(framer),
       owns_framer_(owns_framer),
       helper_(helper),
@@ -268,12 +269,11 @@ QuicConnection::QuicConnection(QuicConnectionId connection_id,
       packets_between_mtu_probes_(kPacketsBetweenMtuProbesBase),
       next_mtu_probe_at_(kPacketsBetweenMtuProbesBase),
       largest_received_packet_size_(0),
-      goaway_sent_(false),
-      goaway_received_(false),
       write_error_occured_(false),
       no_stop_waiting_frames_(false),
       consecutive_num_packets_with_no_retransmittable_frames_(0),
-      subflow_state_(SUBFLOW_OPEN_INITIATED) {
+      subflow_state_(SUBFLOW_OPEN_INITIATED),
+      subflow_id_(subflow_id) {
   QUIC_DLOG(INFO) << ENDPOINT
                   << "Created connection with connection_id: " << connection_id;
   framer_->set_visitor(this);
@@ -290,6 +290,9 @@ QuicConnection::QuicConnection(QuicConnectionId connection_id,
     QUIC_FLAG_COUNT_N(quic_reloadable_flag_quic_no_stop_waiting_frames, 1, 2);
     received_packet_manager_.set_max_ack_ranges(255);
   }
+
+  // Set the subflow id field in the ACK packet
+  received_packet_manager_.SetSubflowId(subflow_id_);
 
   // Create a connection for a subflow without exchanging handshake messages
   // using a previously established crypto context.
@@ -315,7 +318,8 @@ QuicConnection::QuicConnection(QuicConnectionId connection_id,
         writer,
         owns_writer,
         perspective,
-        supported_versions)
+        supported_versions,
+        kInitialSubflowId)
 {
 }
 
@@ -327,7 +331,8 @@ QuicConnection::QuicConnection(QuicConnectionId connection_id,
                                QuicPacketWriter* writer,
                                bool owns_writer,
                                Perspective perspective,
-                               const QuicVersionVector& supported_versions)
+                               const QuicVersionVector& supported_versions,
+                               QuicSubflowId subflow_id)
     : QuicConnection(connection_id,
         self_address,
         peer_address,
@@ -339,7 +344,8 @@ QuicConnection::QuicConnection(QuicConnectionId connection_id,
         supported_versions,
         new QuicFramer(supported_versions, helper->GetClock()->ApproximateNow(), perspective),
         /* owns_framer */ true,
-        /* do_not_perform_handshake */ false)
+        /* do_not_perform_handshake */ false,
+        subflow_id)
 {
 }
 
@@ -378,11 +384,62 @@ QuicConnection *QuicConnection::CloneToSubflow(
       supported_versions(),
       framer,
       /* owns_framer */ true,
-      /* do_not_perform_handshake */ true);
+      /* do_not_perform_handshake */ true,
+      subflowId);
   connection->SetDefaultEncryptionLevel(encryption_level());
 
   return connection;
 }
+
+void QuicConnection::HandleIncomingAckFrame(
+    const QuicAckFrame& frame,
+    const QuicTime& arrival_time_of_packet) {
+  DCHECK(connected_);
+  if (debug_visitor_ != nullptr) {
+    debug_visitor_->OnAckFrame(frame);
+  }
+  QUIC_DVLOG(1) << ENDPOINT << "OnAckFrame: " << frame;
+
+  if (last_header_.packet_number <= largest_seen_packet_with_ack_) {
+    QUIC_DLOG(INFO) << ENDPOINT << "Received an old ack frame: ignoring";
+    return true;
+  }
+
+  const char* error = ValidateAckFrame(frame);
+  if (error != nullptr) {
+    CloseConnection(QUIC_INVALID_ACK_DATA, error,
+                    ConnectionCloseBehavior::SEND_CONNECTION_CLOSE_PACKET);
+    return false;
+  }
+
+  if (send_alarm_->IsSet()) {
+    send_alarm_->Cancel();
+  }
+  largest_seen_packet_with_ack_ = last_header_.packet_number;
+  sent_packet_manager_.OnIncomingAck(frame,
+                                     arrival_time_of_packet);
+  if (no_stop_waiting_frames_) {
+    received_packet_manager_.DontWaitForPacketsBefore(
+        sent_packet_manager_.largest_packet_peer_knows_is_acked());
+  }
+  // Always reset the retransmission alarm when an ack comes in, since we now
+  // have a better estimate of the current rtt than when it was set.
+  SetRetransmissionAlarm();
+
+  // If the incoming ack's packets set expresses missing packets: peer is still
+  // waiting for a packet lower than a packet that we are no longer planning to
+  // send.
+  // If the incoming ack's packets set expresses received packets: peer is still
+  // acking packets which we never care about.
+  // Send an ack to raise the high water mark.
+  if (!frame.packets.Empty() &&
+      GetLeastUnacked() > frame.packets.Min()) {
+    ++stop_waiting_count_;
+  } else {
+    stop_waiting_count_ = 0;
+  }
+}
+
 
 void QuicConnection::PrependNewSubflowFrame(QuicSubflowId subflowId) {
   QuicFrames frames;
@@ -521,6 +578,12 @@ bool QuicConnection::SelectMutualVersion(
   return false;
 }
 
+void QuicConnection::OnRetransmission(const QuicTransmissionInfo& transmission_info) {
+  if(visitor_) {
+    visitor_->OnRetransmission(transmission_info);
+  }
+}
+
 void QuicConnection::OnError(QuicFramer* framer) {
   // Packets that we can not or have not decrypted are dropped.
   // TODO(rch): add stats to measure this.
@@ -592,7 +655,7 @@ bool QuicConnection::OnProtocolVersionMismatch(QuicVersion received_version) {
   }
 
   version_negotiation_state_ = NEGOTIATED_VERSION;
-  visitor_->OnSuccessfulVersionNegotiation(received_version);
+  visitor_->OnSuccessfulVersionNegotiation(subflow_id_,received_version);
   if (debug_visitor_ != nullptr) {
     debug_visitor_->OnSuccessfulVersionNegotiation(received_version);
   }
@@ -790,59 +853,17 @@ bool QuicConnection::OnStreamFrame(const QuicStreamFrame& frame) {
                     ConnectionCloseBehavior::SEND_CONNECTION_CLOSE_PACKET);
     return false;
   }
-  visitor_->OnStreamFrame(frame);
-  visitor_->PostProcessAfterData();
+  visitor_->OnStreamFrame(subflow_id_,frame);
+  visitor_->PostProcessAfterData(subflow_id_);
   stats_.stream_bytes_received += frame.data_length;
   should_last_packet_instigate_acks_ = true;
   return connected_;
 }
 
 bool QuicConnection::OnAckFrame(const QuicAckFrame& incoming_ack) {
-  DCHECK(connected_);
-  if (debug_visitor_ != nullptr) {
-    debug_visitor_->OnAckFrame(incoming_ack);
+  if(visitor_) {
+    visitor_->OnAckFrame(subflow_id_, incoming_ack, time_of_last_received_packet_);
   }
-  QUIC_DVLOG(1) << ENDPOINT << "OnAckFrame: " << incoming_ack;
-
-  if (last_header_.packet_number <= largest_seen_packet_with_ack_) {
-    QUIC_DLOG(INFO) << ENDPOINT << "Received an old ack frame: ignoring";
-    return true;
-  }
-
-  const char* error = ValidateAckFrame(incoming_ack);
-  if (error != nullptr) {
-    CloseConnection(QUIC_INVALID_ACK_DATA, error,
-                    ConnectionCloseBehavior::SEND_CONNECTION_CLOSE_PACKET);
-    return false;
-  }
-
-  if (send_alarm_->IsSet()) {
-    send_alarm_->Cancel();
-  }
-  largest_seen_packet_with_ack_ = last_header_.packet_number;
-  sent_packet_manager_.OnIncomingAck(incoming_ack,
-                                     time_of_last_received_packet_);
-  if (no_stop_waiting_frames_) {
-    received_packet_manager_.DontWaitForPacketsBefore(
-        sent_packet_manager_.largest_packet_peer_knows_is_acked());
-  }
-  // Always reset the retransmission alarm when an ack comes in, since we now
-  // have a better estimate of the current rtt than when it was set.
-  SetRetransmissionAlarm();
-
-  // If the incoming ack's packets set expresses missing packets: peer is still
-  // waiting for a packet lower than a packet that we are no longer planning to
-  // send.
-  // If the incoming ack's packets set expresses received packets: peer is still
-  // acking packets which we never care about.
-  // Send an ack to raise the high water mark.
-  if (!incoming_ack.packets.Empty() &&
-      GetLeastUnacked() > incoming_ack.packets.Min()) {
-    ++stop_waiting_count_;
-  } else {
-    stop_waiting_count_ = 0;
-  }
-
   return connected_;
 }
 
@@ -956,8 +977,8 @@ bool QuicConnection::OnRstStreamFrame(const QuicRstStreamFrame& frame) {
                   << "RST_STREAM_FRAME received for stream: " << frame.stream_id
                   << " with error: "
                   << QuicRstStreamErrorCodeToString(frame.error_code);
-  visitor_->OnRstStream(frame);
-  visitor_->PostProcessAfterData();
+  visitor_->OnRstStream(subflow_id_,frame);
+  visitor_->PostProcessAfterData(subflow_id_);
   should_last_packet_instigate_acks_ = true;
   return connected_;
 }
@@ -992,9 +1013,8 @@ bool QuicConnection::OnGoAwayFrame(const QuicGoAwayFrame& frame) {
                   << " and error: " << QuicErrorCodeToString(frame.error_code)
                   << " and reason: " << frame.reason_phrase;
 
-  goaway_received_ = true;
-  visitor_->OnGoAway(frame);
-  visitor_->PostProcessAfterData();
+  visitor_->OnGoAway(subflow_id_,frame);
+  visitor_->PostProcessAfterData(subflow_id_);
   should_last_packet_instigate_acks_ = true;
   return connected_;
 }
@@ -1007,8 +1027,8 @@ bool QuicConnection::OnWindowUpdateFrame(const QuicWindowUpdateFrame& frame) {
   QUIC_DLOG(INFO) << ENDPOINT << "WINDOW_UPDATE_FRAME received for stream: "
                   << frame.stream_id
                   << " with byte offset: " << frame.byte_offset;
-  visitor_->OnWindowUpdateFrame(frame);
-  visitor_->PostProcessAfterData();
+  visitor_->OnWindowUpdateFrame(subflow_id_,frame);
+  visitor_->PostProcessAfterData(subflow_id_);
   should_last_packet_instigate_acks_ = true;
   return connected_;
 }
@@ -1020,8 +1040,8 @@ bool QuicConnection::OnBlockedFrame(const QuicBlockedFrame& frame) {
   }
   QUIC_DLOG(INFO) << ENDPOINT
                   << "BLOCKED_FRAME received for stream: " << frame.stream_id;
-  visitor_->OnBlockedFrame(frame);
-  visitor_->PostProcessAfterData();
+  visitor_->OnBlockedFrame(subflow_id_,frame);
+  visitor_->PostProcessAfterData(subflow_id_);
   stats_.blocked_frames_received++;
   should_last_packet_instigate_acks_ = true;
   return connected_;
@@ -1038,7 +1058,7 @@ bool QuicConnection::OnSubflowCloseFrame(const QuicSubflowCloseFrame& frame) {
   DCHECK(connected_);
   QUIC_DLOG(INFO) << ENDPOINT
                   << "SUBFLOW_CLOSE_FRAME received for subflow: " << frame.subflow_id;
-  visitor_->OnSubflowCloseFrame(frame);
+  visitor_->OnSubflowCloseFrame(subflow_id_,frame);
   return connected_;
 }
 
@@ -1134,7 +1154,8 @@ void QuicConnection::ClearLastFrames() {
   should_last_packet_instigate_acks_ = false;
 }
 
-const QuicFrame QuicConnection::GetUpdatedAckFrame() {
+const QuicFrames QuicConnection::GetUpdatedAckFrames() {
+  //TODO(cyrill) call visitor and collect all updated ack frames.
   return received_packet_manager_.GetUpdatedAckFrame(clock_->ApproximateNow());
 }
 
@@ -1163,7 +1184,7 @@ void QuicConnection::MaybeSendInResponseToPacket() {
 void QuicConnection::SendVersionNegotiationPacket() {
   pending_version_negotiation_packet_ = true;
   if (writer_->IsWriteBlocked()) {
-    visitor_->OnWriteBlocked();
+    visitor_->OnWriteBlocked(subflow_id_);
     return;
   }
   QUIC_DLOG(INFO) << ENDPOINT << "Sending version negotiation packet: {"
@@ -1181,7 +1202,7 @@ void QuicConnection::SendVersionNegotiationPacket() {
     return;
   }
   if (result.status == WRITE_STATUS_BLOCKED) {
-    visitor_->OnWriteBlocked();
+    visitor_->OnWriteBlocked(subflow_id_);
     if (writer_->IsWriteBlockedDataBuffered()) {
       pending_version_negotiation_packet_ = false;
     }
@@ -1380,13 +1401,13 @@ void QuicConnection::OnCanWrite() {
 
   {
     ScopedPacketBundler bundler(this, SEND_ACK_IF_QUEUED);
-    visitor_->OnCanWrite();
-    visitor_->PostProcessAfterData();
+    visitor_->OnCanWrite(subflow_id_);
+    visitor_->PostProcessAfterData(subflow_id_);
   }
 
   // After the visitor writes, it may have caused the socket to become write
   // blocked or the congestion manager to prohibit sending, so check again.
-  if (visitor_->WillingAndAbleToWrite() && !resume_writes_alarm_->IsSet() &&
+  if (visitor_->WillingAndAbleToWrite(subflow_id_) && !resume_writes_alarm_->IsSet() &&
       CanWrite(HAS_RETRANSMITTABLE_DATA)) {
     // We're not write blocked, but some stream didn't write out all of its
     // bytes. Register for 'immediate' resumption so we'll keep writing after
@@ -1465,7 +1486,7 @@ bool QuicConnection::ProcessValidatedPacket(const QuicPacketHeader& header) {
         DCHECK_EQ(1u, header.public_header.versions.size());
         DCHECK_EQ(header.public_header.versions[0], version());
         version_negotiation_state_ = NEGOTIATED_VERSION;
-        visitor_->OnSuccessfulVersionNegotiation(version());
+        visitor_->OnSuccessfulVersionNegotiation(subflow_id_,version());
         if (debug_visitor_ != nullptr) {
           debug_visitor_->OnSuccessfulVersionNegotiation(version());
         }
@@ -1476,7 +1497,7 @@ bool QuicConnection::ProcessValidatedPacket(const QuicPacketHeader& header) {
       // it should stop sending version since the version negotiation is done.
       packet_generator_.StopSendingVersion();
       version_negotiation_state_ = NEGOTIATED_VERSION;
-      visitor_->OnSuccessfulVersionNegotiation(version());
+      visitor_->OnSuccessfulVersionNegotiation(subflow_id_,version());
       if (debug_visitor_ != nullptr) {
         debug_visitor_->OnSuccessfulVersionNegotiation(version());
       }
@@ -1566,7 +1587,7 @@ bool QuicConnection::CanWrite(HasRetransmittableData retransmittable) {
   }
 
   if (writer_->IsWriteBlocked()) {
-    visitor_->OnWriteBlocked();
+    visitor_->OnWriteBlocked(subflow_id_);
     return false;
   }
 
@@ -1631,7 +1652,7 @@ bool QuicConnection::WritePacket(SerializedPacket* packet) {
     // This assures we won't try to write *forced* packets when blocked.
     // Return true to stop processing.
     if (writer_->IsWriteBlocked()) {
-      visitor_->OnWriteBlocked();
+      visitor_->OnWriteBlocked(subflow_id_);
       return true;
     }
   }
@@ -1661,7 +1682,7 @@ bool QuicConnection::WritePacket(SerializedPacket* packet) {
   }
 
   if (result.status == WRITE_STATUS_BLOCKED) {
-    visitor_->OnWriteBlocked();
+    visitor_->OnWriteBlocked(subflow_id_);
     // If the socket buffers the the data, then the packet should not
     // be queued and sent again, which would result in an unnecessary
     // duplicate packet being sent.  The helper must call OnCanWrite
@@ -1822,7 +1843,7 @@ void QuicConnection::OnUnrecoverableError(QuicErrorCode error,
 }
 
 void QuicConnection::OnCongestionChange() {
-  visitor_->OnCongestionWindowChange(clock_->ApproximateNow());
+  visitor_->OnCongestionWindowChange(subflow_id_,clock_->ApproximateNow());
 
   // Uses the connection's smoothed RTT. If zero, uses initial_rtt.
   QuicTime::Delta rtt = sent_packet_manager_.GetRttStats()->smoothed_rtt();
@@ -1837,7 +1858,7 @@ void QuicConnection::OnCongestionChange() {
 }
 
 void QuicConnection::OnPathDegrading() {
-  visitor_->OnPathDegrading();
+  visitor_->OnPathDegrading(subflow_id_);
 }
 
 void QuicConnection::OnPathMtuIncreased(QuicPacketLength packet_size) {
@@ -1909,7 +1930,7 @@ void QuicConnection::SendAck() {
     return;
   }
 
-  visitor_->OnAckNeedsRetransmittableFrame();
+  visitor_->OnAckNeedsRetransmittableFrame(subflow_id_);
   if (!packet_generator_.HasRetransmittableFrames()) {
     // Visitor did not add a retransmittable frame, add a ping frame.
     packet_generator_.AddControlFrame(QuicFrame(QuicPingFrame()));
@@ -1921,7 +1942,7 @@ void QuicConnection::OnRetransmissionTimeout() {
 
   if (close_connection_after_three_rtos_ &&
       sent_packet_manager_.GetConsecutiveRtoCount() >= 2 &&
-      !visitor_->HasOpenDynamicStreams()) {
+      !visitor_->HasOpenDynamicStreams(subflow_id_)) {
     // Close on the 3rd consecutive RTO, so after 2 previous RTOs have occurred.
     CloseConnection(QUIC_TOO_MANY_RTOS, "3 consecutive retransmission timeouts",
                     ConnectionCloseBehavior::SEND_CONNECTION_CLOSE_PACKET);
@@ -2095,7 +2116,7 @@ void QuicConnection::TearDownLocalConnectionState(
   // |visitor_| to fix crash bug. Delete |visitor_| check and histogram after
   // fix is merged.
   if (notify_visitor && visitor_ != nullptr) {
-    visitor_->OnConnectionClosed(error, error_details, source);
+    visitor_->OnConnectionClosed(subflow_id_, error, error_details, source);
   } else {
     UMA_HISTOGRAM_BOOLEAN("Net.QuicCloseConnection.NullVisitor", true);
   }
@@ -2122,11 +2143,6 @@ void QuicConnection::CancelAllAlarms() {
 void QuicConnection::SendGoAway(QuicErrorCode error,
                                 QuicStreamId last_good_stream_id,
                                 const string& reason) {
-  if (goaway_sent_) {
-    return;
-  }
-  goaway_sent_ = true;
-
   QUIC_DLOG(INFO) << ENDPOINT << "Going away with error "
                   << QuicErrorCodeToString(error) << " (" << error << ")";
 
@@ -2162,7 +2178,7 @@ bool QuicConnection::CanWriteStreamData() {
   }
 
   IsHandshake pending_handshake =
-      visitor_->HasPendingHandshake() ? IS_HANDSHAKE : NOT_HANDSHAKE;
+      visitor_->HasPendingHandshake(subflow_id_) ? IS_HANDSHAKE : NOT_HANDSHAKE;
   // Sending queued packets may have caused the socket to become write blocked,
   // or the congestion manager to prohibit sending.  If we've sent everything
   // we had queued and we're still not blocked, let the visitor know it can
@@ -2249,7 +2265,7 @@ void QuicConnection::SetPingAlarm() {
     // Only clients send pings.
     return;
   }
-  if (!visitor_->HasOpenDynamicStreams()) {
+  if (!visitor_->HasOpenDynamicStreams(subflow_id_)) {
     ping_alarm_->Cancel();
     // Don't send a ping unless there are open streams.
     return;
@@ -2502,7 +2518,7 @@ void QuicConnection::StartPeerMigration(
 
   // TODO(jri): Move these calls to OnPeerMigrationValidated. Rename
   // OnConnectionMigration methods to OnPeerMigration.
-  visitor_->OnConnectionMigration(peer_migration_type);
+  visitor_->OnConnectionMigration(subflow_id_, peer_migration_type);
   sent_packet_manager_.OnConnectionMigration(peer_migration_type);
 }
 
@@ -2563,7 +2579,7 @@ const QuicTime::Delta QuicConnection::DelayedAckTime() {
 void QuicConnection::CheckIfApplicationLimited() {
   if (queued_packets_.empty() &&
       !sent_packet_manager_.HasPendingRetransmissions() &&
-      !visitor_->WillingAndAbleToWrite()) {
+      !visitor_->WillingAndAbleToWrite(subflow_id_)) {
     sent_packet_manager_.OnApplicationLimited();
   }
 }

--- a/src/net/quic/core/quic_connection.h
+++ b/src/net/quic/core/quic_connection.h
@@ -170,6 +170,8 @@ class QUIC_EXPORT_PRIVATE QuicConnectionVisitorInterface {
   virtual void OnSubflowCloseFrame(const QuicSubflowId& subflowId, const QuicSubflowCloseFrame& frame) = 0;
 
   virtual void OnRetransmission(const QuicTransmissionInfo& transmission_info) = 0;
+
+  virtual QuicFrames GetUpdatedAckFrames(const QuicSubflowId& subflow_id, const QuicTime& now) = 0;
 };
 
 // Interface which gets callbacks from the QuicConnection at interesting
@@ -386,7 +388,7 @@ class QUIC_EXPORT_PRIVATE QuicConnection
 
   void HandleIncomingAckFrame(
       const QuicAckFrame& frame,
-      const QuicTime& arrival_time_of_packet) = 0;
+      const QuicTime& arrival_time_of_packet);
 
   // Adds a NEW_SUBFLOW frame as the first frame in every sent packet.
   void PrependNewSubflowFrame(QuicSubflowId subflowId);

--- a/src/net/quic/core/quic_connection.h
+++ b/src/net/quic/core/quic_connection.h
@@ -97,77 +97,76 @@ class QUIC_EXPORT_PRIVATE QuicConnectionVisitorInterface {
   virtual ~QuicConnectionVisitorInterface() {}
 
   // A simple visitor interface for dealing with a data frame.
-  virtual void OnStreamFrame(const QuicStreamFrame& frame) = 0;
+  virtual void OnStreamFrame(const QuicSubflowId& subflowId, const QuicStreamFrame& frame) = 0;
 
   // The session should process the WINDOW_UPDATE frame, adjusting both stream
   // and connection level flow control windows.
-  virtual void OnWindowUpdateFrame(const QuicWindowUpdateFrame& frame) = 0;
+  virtual void OnWindowUpdateFrame(const QuicSubflowId& subflowId, const QuicWindowUpdateFrame& frame) = 0;
 
   // A BLOCKED frame indicates the peer is flow control blocked
   // on a specified stream.
-  virtual void OnBlockedFrame(const QuicBlockedFrame& frame) = 0;
+  virtual void OnBlockedFrame(const QuicSubflowId& subflowId, const QuicBlockedFrame& frame) = 0;
 
   // Called when the stream is reset by the peer.
-  virtual void OnRstStream(const QuicRstStreamFrame& frame) = 0;
+  virtual void OnRstStream(const QuicSubflowId& subflowId, const QuicRstStreamFrame& frame) = 0;
 
   // Called when the connection is going away according to the peer.
-  virtual void OnGoAway(const QuicGoAwayFrame& frame) = 0;
+  virtual void OnGoAway(const QuicSubflowId& subflowId, const QuicGoAwayFrame& frame) = 0;
 
   // Called when the connection is closed either locally by the framer, or
   // remotely by the peer.
-  virtual void OnConnectionClosed(QuicErrorCode error,
+  virtual void OnConnectionClosed(const QuicSubflowId& subflowId,
+                                  QuicErrorCode error,
                                   const std::string& error_details,
                                   ConnectionCloseSource source) = 0;
 
   // Called when the connection failed to write because the socket was blocked.
-  virtual void OnWriteBlocked() = 0;
+  virtual void OnWriteBlocked(const QuicSubflowId& subflowId) = 0;
 
   // Called once a specific QUIC version is agreed by both endpoints.
-  virtual void OnSuccessfulVersionNegotiation(const QuicVersion& version) = 0;
+  virtual void OnSuccessfulVersionNegotiation(const QuicSubflowId& subflowId, const QuicVersion& version) = 0;
 
   // Called when a blocked socket becomes writable.
-  virtual void OnCanWrite() = 0;
+  virtual void OnCanWrite(const QuicSubflowId& subflowId) = 0;
 
   // Called when the connection experiences a change in congestion window.
-  virtual void OnCongestionWindowChange(QuicTime now) = 0;
+  virtual void OnCongestionWindowChange(const QuicSubflowId& subflowId, QuicTime now) = 0;
 
   // Called when the connection receives a packet from a migrated client.
-  virtual void OnConnectionMigration(PeerAddressChangeType type) = 0;
+  virtual void OnConnectionMigration(const QuicSubflowId& subflowId, PeerAddressChangeType type) = 0;
 
   // Called when the peer seems unreachable over the current path.
-  virtual void OnPathDegrading() = 0;
+  virtual void OnPathDegrading(const QuicSubflowId& subflowId) = 0;
 
   // Called after OnStreamFrame, OnRstStream, OnGoAway, OnWindowUpdateFrame,
   // OnBlockedFrame, and OnCanWrite to allow post-processing once the work has
   // been done.
-  virtual void PostProcessAfterData() = 0;
+  virtual void PostProcessAfterData(const QuicSubflowId& subflowId) = 0;
 
   // Called when the connection sends ack after
   // kMaxConsecutiveNonRetransmittablePackets consecutive not retransmittable
   // packets sent. To instigate an ack from peer, a retransmittable frame needs
   // to be added.
-  virtual void OnAckNeedsRetransmittableFrame() = 0;
+  virtual void OnAckNeedsRetransmittableFrame(const QuicSubflowId& subflowId) = 0;
 
   // Called to ask if the visitor wants to schedule write resumption as it both
   // has pending data to write, and is able to write (e.g. based on flow control
   // limits).
   // Writes may be pending because they were write-blocked, congestion-throttled
   // or yielded to other connections.
-  virtual bool WillingAndAbleToWrite() const = 0;
+  virtual bool WillingAndAbleToWrite(const QuicSubflowId& subflowId) const = 0;
 
   // Called to ask if any handshake messages are pending in this visitor.
-  virtual bool HasPendingHandshake() const = 0;
+  virtual bool HasPendingHandshake(const QuicSubflowId& subflowId) const = 0;
 
   // Called to ask if any streams are open in this visitor, excluding the
   // reserved crypto and headers stream.
-  virtual bool HasOpenDynamicStreams() const = 0;
+  virtual bool HasOpenDynamicStreams(const QuicSubflowId& subflowId) const = 0;
 
   // Called whenever an ACK frame is received
-  virtual void OnAckFrame(const QuicAckFrame& frame) = 0;
+  virtual void OnAckFrame(const QuicSubflowId& subflowId, const QuicAckFrame& frame) = 0;
 
-  virtual void OnHandshakeComplete() = 0;
-
-  virtual void OnSubflowCloseFrame(const QuicSubflowCloseFrame& frame) = 0;
+  virtual void OnSubflowCloseFrame(const QuicSubflowId& subflowId, const QuicSubflowCloseFrame& frame) = 0;
 };
 
 // Interface which gets callbacks from the QuicConnection at interesting

--- a/src/net/quic/core/quic_connection_manager.cc
+++ b/src/net/quic/core/quic_connection_manager.cc
@@ -387,10 +387,22 @@ void QuicConnectionManager::OnSubflowCloseFrame(const QuicSubflowId& subflowId, 
     //TODO error handling
   }
 }
+QuicFrames QuicConnectionManager::GetUpdatedAckFrames(const QuicSubflowId& subflow_id) {
+  QuicTime now = AnyConnection()->clock()->ApproximateNow();
+  QuicFrames frames;
+  for(auto it = connections_.begin(); it != connections_.end(); ++it) {
+    frames.push_back(it->second->GetUpdatedAckFrame(now));
+  }
+  return frames;
+}
 
 void QuicConnectionManager::OnRetransmission(const QuicTransmissionInfo& transmission_info) {
+  QuicConnection* connection = CurrentConnection();
+  // bundled_packet_handler?
+  
   // add frames to some connection
-
+  for(auto it : transmission_info->retransmittable_frames) {
+    connection->
 }
 
 

--- a/src/net/quic/core/quic_connection_manager.cc
+++ b/src/net/quic/core/quic_connection_manager.cc
@@ -202,46 +202,50 @@ QuicSubflowId QuicConnectionManager::GetNextOutgoingSubflowId() {
   return id;
 }
 
-void QuicConnectionManager::OnStreamFrame(const QuicStreamFrame& frame) {
-  if(visitor_ != nullptr) visitor_->OnStreamFrame(frame);
+void QuicConnectionManager::OnStreamFrame(const QuicSubflowId& subflowId, const QuicStreamFrame& frame) {
+  if(visitor_) visitor_->OnStreamFrame(frame);
 }
-void QuicConnectionManager::OnWindowUpdateFrame(const QuicWindowUpdateFrame& frame) {
-  if(visitor_ != nullptr) visitor_->OnWindowUpdateFrame(frame);
+void QuicConnectionManager::OnWindowUpdateFrame(const QuicSubflowId& subflowId, const QuicWindowUpdateFrame& frame) {
+  if(visitor_) visitor_->OnWindowUpdateFrame(frame);
 }
-void QuicConnectionManager::OnBlockedFrame(const QuicBlockedFrame& frame) {
-  if(visitor_ != nullptr) visitor_->OnBlockedFrame(frame);
+void QuicConnectionManager::OnBlockedFrame(const QuicSubflowId& subflowId, const QuicBlockedFrame& frame) {
+  if(visitor_) visitor_->OnBlockedFrame(frame);
 }
-void QuicConnectionManager::OnRstStream(const QuicRstStreamFrame& frame) {
-  if(visitor_ != nullptr) visitor_->OnRstStream(frame);
+void QuicConnectionManager::OnRstStream(const QuicSubflowId& subflowId, const QuicRstStreamFrame& frame) {
+  if(visitor_) visitor_->OnRstStream(frame);
 }
-void QuicConnectionManager::OnGoAway(const QuicGoAwayFrame& frame) {
-  if(visitor_ != nullptr) visitor_->OnGoAway(frame);
+void QuicConnectionManager::OnGoAway(const QuicSubflowId& subflowId, const QuicGoAwayFrame& frame) {
+  if(visitor_) visitor_->OnGoAway(frame);
 }
-void QuicConnectionManager::OnConnectionClosed(QuicErrorCode error,
+void QuicConnectionManager::OnConnectionClosed(const QuicSubflowId& subflowId, QuicErrorCode error,
     const std::string& error_details, ConnectionCloseSource source) {
   for(auto it = connections_.begin(); it != connections_.end(); ++it) {
-    // No need to notify visitor
-    it->second->TearDownLocalConnectionState(error,error_details,source,false);
+    if(it->first != subflowId) {
+      // No need to notify visitor
+      it->second->TearDownLocalConnectionState(error,error_details,source,false);
+    }
   }
-  if(visitor_ != nullptr) visitor_->OnConnectionClosed(error,error_details,source);
+  if(visitor_) visitor_->OnConnectionClosed(error,error_details,source);
 }
-void QuicConnectionManager::OnWriteBlocked() {
-  if(visitor_ != nullptr) visitor_->OnWriteBlocked();
+void QuicConnectionManager::OnWriteBlocked(const QuicSubflowId& subflowId) {
+  //TODO maybe use a different subflow if this one is write blocked
+  if(visitor_) visitor_->OnWriteBlocked(connections_[subflowId]);
 }
-void QuicConnectionManager::OnSuccessfulVersionNegotiation(const QuicVersion& version) {
-  if(visitor_ != nullptr) visitor_->OnSuccessfulVersionNegotiation(version);
+void QuicConnectionManager::OnSuccessfulVersionNegotiation(const QuicSubflowId& subflowId, const QuicVersion& version) {
+  if(visitor_) visitor_->OnSuccessfulVersionNegotiation(version);
 }
-void QuicConnectionManager::OnCanWrite() {
-  if(visitor_ != nullptr) visitor_->OnCanWrite();
+void QuicConnectionManager::OnCanWrite(const QuicSubflowId& subflowId) {
+  if(visitor_) visitor_->OnCanWrite(connections_[subflowId]);
 }
-void QuicConnectionManager::OnCongestionWindowChange(QuicTime now) {
-  if(visitor_ != nullptr) visitor_->OnCongestionWindowChange(now);
+void QuicConnectionManager::OnCongestionWindowChange(const QuicSubflowId& subflowId, QuicTime now) {
+  if(visitor_) visitor_->OnCongestionWindowChange(now);
 }
-void QuicConnectionManager::OnConnectionMigration(PeerAddressChangeType type) {
-  if(visitor_ != nullptr) visitor_->OnConnectionMigration(type);
+void QuicConnectionManager::OnConnectionMigration(const QuicSubflowId& subflowId, PeerAddressChangeType type) {
+  if(visitor_) visitor_->OnConnectionMigration(type);
 }
-void QuicConnectionManager::OnPathDegrading() {
-  if(visitor_ != nullptr) visitor_->OnPathDegrading();
+void QuicConnectionManager::OnPathDegrading(const QuicSubflowId& subflowId) {
+  //TODO only send if all paths are degrading?
+  if(visitor_) visitor_->OnPathDegrading();
 }
 void QuicConnectionManager::PostProcessAfterData() {
   if(visitor_ != nullptr) visitor_->PostProcessAfterData();

--- a/src/net/quic/core/quic_connection_manager.h
+++ b/src/net/quic/core/quic_connection_manager.h
@@ -130,6 +130,9 @@ public:
                                      const QuicSocketAddress& peer_address,
                                      const QuicReceivedPacket& packet);
 
+  // Called when the CryptoHandshakeEvent HANDSHAKE_CONFIRMED was received.
+  void OnHandshakeComplete();
+
   // QuicSubflowCreationAttemptDelegate
   //void OnSubflowCreationFailed(QuicSubflowId id) override;
 

--- a/src/net/quic/core/quic_constants.h
+++ b/src/net/quic/core/quic_constants.h
@@ -72,6 +72,8 @@ const size_t kDefaultMaxStreamsPerConnection = 100;
 // The subflow id of the initial connection
 const uint32_t kInitialSubflowId = 1;
 
+const uint32_t kMaxAckFramesPerResponse = 5;
+
 // Number of bytes reserved for public flags in the packet header.
 const size_t kPublicFlagsSize = 1;
 // Number of bytes reserved for version number in the packet header.

--- a/src/net/quic/core/quic_crypto_stream.cc
+++ b/src/net/quic/core/quic_crypto_stream.cc
@@ -24,10 +24,14 @@ namespace net {
                                                                      " ")
 
 QuicCryptoStream::QuicCryptoStream(QuicSession* session)
+    : QuicCryptoStream(session,session->InitialConnection()) {}
+
+QuicCryptoStream::QuicCryptoStream(QuicSession* session, QuicConnection* connection)
     : QuicStream(kCryptoStreamId, session),
       encryption_established_(false),
       handshake_confirmed_(false),
-      crypto_negotiated_params_(new QuicCryptoNegotiatedParameters) {
+      crypto_negotiated_params_(new QuicCryptoNegotiatedParameters),
+      connection_(connection) {
   crypto_framer_.set_visitor(this);
   // The crypto stream is exempt from connection level flow control.
   DisableConnectionFlowControlForThisStream();
@@ -86,7 +90,7 @@ void QuicCryptoStream::SendHandshakeMessage(
     const CryptoHandshakeMessage& message) {
   QUIC_DVLOG(1) << ENDPOINT << "Sending "
                 << message.DebugString(session()->perspective());
-  session()->connection()->NeuterUnencryptedPackets();
+  connection()->NeuterUnencryptedPackets();
   session()->OnCryptoHandshakeMessageSent(message);
   const QuicData& data = message.GetSerialized(session()->perspective());
   WriteOrBufferData(QuicStringPiece(data.data(), data.length()), false,

--- a/src/net/quic/core/quic_crypto_stream.h
+++ b/src/net/quic/core/quic_crypto_stream.h
@@ -35,7 +35,8 @@ class QUIC_EXPORT_PRIVATE QuicCryptoStream
     : public QuicStream,
       public CryptoFramerVisitorInterface {
  public:
-  explicit QuicCryptoStream(QuicSession* session);
+      explicit QuicCryptoStream(QuicSession* session);
+      explicit QuicCryptoStream(QuicSession* session, QuicConnection* connection);
 
   ~QuicCryptoStream() override;
 
@@ -85,8 +86,14 @@ class QUIC_EXPORT_PRIVATE QuicCryptoStream
   QuicReferenceCountedPointer<QuicCryptoNegotiatedParameters>
       crypto_negotiated_params_;
 
+  QuicConnection* connection() { return connection_; }
+
  private:
   CryptoFramer crypto_framer_;
+
+  // The connection on which the crypto handshake should be performed.
+  // (not owned)
+  QuicConnection* connection_;
 
   DISALLOW_COPY_AND_ASSIGN(QuicCryptoStream);
 };

--- a/src/net/quic/core/quic_flow_controller.h
+++ b/src/net/quic/core/quic_flow_controller.h
@@ -8,6 +8,7 @@
 #include "base/macros.h"
 #include "net/quic/core/quic_packets.h"
 #include "net/quic/platform/api/quic_export.h"
+#include "net/quic/core/quic_connection_manager.h"
 
 namespace net {
 
@@ -39,7 +40,7 @@ class QUIC_EXPORT_PRIVATE QuicFlowControllerInterface {
 class QUIC_EXPORT_PRIVATE QuicFlowController
     : public QuicFlowControllerInterface {
  public:
-  QuicFlowController(QuicConnection* connection,
+  QuicFlowController(QuicConnectionManager* connection_manager_,
                      QuicStreamId id,
                      Perspective perspective,
                      QuicStreamOffset send_window_size,
@@ -122,10 +123,10 @@ class QUIC_EXPORT_PRIVATE QuicFlowController
   // Double the window size as long as we haven't hit the max window size.
   void IncreaseWindowSize();
 
-  // The parent connection, used to send connection close on flow control
+  // The parent connection manager, used to send connection close on flow control
   // violation, and WINDOW_UPDATE and BLOCKED frames when appropriate.
   // Not owned.
-  QuicConnection* connection_;
+  QuicConnectionManager* connection_manager_;
 
   // ID of stream this flow controller belongs to. This can be 0 if this is a
   // connection level flow controller.

--- a/src/net/quic/core/quic_packet_generator.cc
+++ b/src/net/quic/core/quic_packet_generator.cc
@@ -252,8 +252,12 @@ bool QuicPacketGenerator::HasPendingFrames() const {
 
 bool QuicPacketGenerator::AddNextPendingFrame() {
   if (should_send_ack_) {
-    should_send_ack_ =
-        !packet_creator_.AddSavedFrame(delegate_->GetUpdatedAckFrame());
+    should_send_ack_ = false;
+    for(const QuicFrame &frame: delegate_->GetUpdatedAckFrames()) {
+      if(!packet_creator_.AddSavedFrame(frame)) {
+        should_send_ack_ = true;
+      }
+    }
     return !should_send_ack_;
   }
 

--- a/src/net/quic/core/quic_packet_generator.h
+++ b/src/net/quic/core/quic_packet_generator.h
@@ -66,7 +66,7 @@ class QUIC_EXPORT_PRIVATE QuicPacketGenerator {
     // Consults delegate whether a packet should be generated.
     virtual bool ShouldGeneratePacket(HasRetransmittableData retransmittable,
                                       IsHandshake handshake) = 0;
-    virtual const QuicFrame GetUpdatedAckFrame() = 0;
+    virtual const QuicFrames GetUpdatedAckFrames() = 0;
     virtual void PopulateStopWaitingFrame(
         QuicStopWaitingFrame* stop_waiting) = 0;
   };

--- a/src/net/quic/core/quic_received_packet_manager.cc
+++ b/src/net/quic/core/quic_received_packet_manager.cc
@@ -34,6 +34,11 @@ QuicReceivedPacketManager::QuicReceivedPacketManager(QuicConnectionStats* stats)
 
 QuicReceivedPacketManager::~QuicReceivedPacketManager() {}
 
+
+void QuicReceivedPacketManager::SetSubflowId(QuicSubflowId subflow_id) {
+  ack_frame_.subflow_id = subflow_id;
+}
+
 void QuicReceivedPacketManager::RecordPacketReceived(
     const QuicPacketHeader& header,
     QuicTime receipt_time) {

--- a/src/net/quic/core/quic_received_packet_manager.h
+++ b/src/net/quic/core/quic_received_packet_manager.h
@@ -25,6 +25,8 @@ class QUIC_EXPORT_PRIVATE QuicReceivedPacketManager {
   explicit QuicReceivedPacketManager(QuicConnectionStats* stats);
   virtual ~QuicReceivedPacketManager();
 
+  void SetSubflowId(QuicSubflowId subflow_id);
+
   // Updates the internal state concerning which packets have been received.
   // header: the packet header.
   // timestamp: the arrival time of the packet.

--- a/src/net/quic/core/quic_sent_packet_manager.cc
+++ b/src/net/quic/core/quic_sent_packet_manager.cc
@@ -368,7 +368,7 @@ void QuicSentPacketManager::MarkForRetransmission(
   // Always send handshake messages on the same connection
   // If we didn't specify a retransmission visitor, retransmit all
   // packets on this connection.
-  if(transmission_type == HANDSHAKE_RETRANSMISSION || retransmission_visitor_ == nullptr) {
+  //if(transmission_type == HANDSHAKE_RETRANSMISSION || retransmission_visitor_ == nullptr) {
 
     // Both TLP and the new RTO leave the packets in flight and let the loss
     // detection decide if packets are lost.
@@ -383,13 +383,15 @@ void QuicSentPacketManager::MarkForRetransmission(
       }
 
     pending_retransmissions_[packet_number] = transmission_type;
-  } else {
+  /*} else {
+    QUIC_LOG(INFO) << "MarkForRetransmission() not handshake";
     // Let the connection manager decide on which subflow to retransmit the packet.
+    DCHECK(false);
     unacked_packets_.RemoveFromInFlight(packet_number);
     if(retransmission_visitor_) {
       retransmission_visitor_->OnRetransmission(unacked_packets_.ExtractTransmissionInfo(packet_number));
     }
-  }
+  }*/
 }
 
 void QuicSentPacketManager::RecordOneSpuriousRetransmission(

--- a/src/net/quic/core/quic_server_session_base.h
+++ b/src/net/quic/core/quic_server_session_base.h
@@ -49,7 +49,7 @@ class QUIC_EXPORT_PRIVATE QuicServerSessionBase : public QuicSpdySession {
 
   // Sends a server config update to the client, containing new bandwidth
   // estimate.
-  void OnCongestionWindowChange(QuicTime now) override;
+  void OnCongestionWindowChange(QuicConnection *connection, QuicTime now) override;
 
   ~QuicServerSessionBase() override;
 
@@ -61,7 +61,7 @@ class QUIC_EXPORT_PRIVATE QuicServerSessionBase : public QuicSpdySession {
 
   // Override base class to process bandwidth related config received from
   // client.
-  void OnConfigNegotiated() override;
+  void OnConfigNegotiated(QuicConnection *connection) override;
 
   void set_serving_region(const std::string& serving_region) {
     serving_region_ = serving_region;

--- a/src/net/quic/core/quic_session.cc
+++ b/src/net/quic/core/quic_session.cc
@@ -137,9 +137,9 @@ void QuicSession::OnConnectionClosed(QuicErrorCode error,
   }
 }
 
-void QuicSession::OnWriteBlocked() {
+void QuicSession::OnWriteBlocked(QuicBlockedWriterInterface* blocked_writer) {
   if (visitor_) {
-    visitor_->OnWriteBlocked(connection());
+    visitor_->OnWriteBlocked(blocked_writer);
   }
 }
 
@@ -213,7 +213,7 @@ bool QuicSession::CheckStreamNotBusyLooping(QuicStream* stream,
   return true;
 }
 
-void QuicSession::OnCanWrite() {
+void QuicSession::OnCanWrite(QuicConnection *connection) {
   // We limit the number of writes to the number of pending streams. If more
   // streams become pending, WillingAndAbleToWrite will be true, which will
   // cause the connection to request resumption before yielding to other

--- a/src/net/quic/core/quic_session.h
+++ b/src/net/quic/core/quic_session.h
@@ -93,9 +93,9 @@ class QUIC_EXPORT_PRIVATE QuicSession : public QuicConnectionManagerVisitorInter
   void OnConnectionClosed(QuicErrorCode error,
                           const std::string& error_details,
                           ConnectionCloseSource source) override;
-  void OnWriteBlocked() override;
+  void OnWriteBlocked(QuicBlockedWriterInterface* blocked_writer) override;
   void OnSuccessfulVersionNegotiation(const QuicVersion& version) override;
-  void OnCanWrite() override;
+  void OnCanWrite(QuicConnection* connection) override;
   void OnCongestionWindowChange(QuicTime /*now*/) override {}
   void OnConnectionMigration(PeerAddressChangeType type) override {}
   // Deletes streams that are safe to be deleted now that it's safe to do so (no

--- a/src/net/quic/core/quic_spdy_session.h
+++ b/src/net/quic/core/quic_spdy_session.h
@@ -124,7 +124,7 @@ class QUIC_EXPORT_PRIVATE QuicSpdySession : public QuicSession {
   // list.
   void UpdateStreamPriority(QuicStreamId id, SpdyPriority new_priority);
 
-  void OnConfigNegotiated() override;
+  void OnConfigNegotiated(QuicConnection *connection) override;
 
   // Called by |headers_stream_| when |force_hol_blocking_| is true.
   virtual void OnStreamFrameData(QuicStreamId stream_id,
@@ -189,7 +189,7 @@ class QUIC_EXPORT_PRIVATE QuicSpdySession : public QuicSession {
   // If an outgoing stream can be created, return true.
   virtual bool ShouldCreateOutgoingDynamicStream() = 0;
 
-  void OnCryptoHandshakeEvent(CryptoHandshakeEvent event) override;
+  void OnCryptoHandshakeEvent(QuicConnection* connection, CryptoHandshakeEvent event) override;
 
   bool supports_push_promise() { return supports_push_promise_; }
 
@@ -212,7 +212,7 @@ class QUIC_EXPORT_PRIVATE QuicSpdySession : public QuicSession {
   // server side.
   void UpdateEnableServerPush(bool value);
 
-  bool IsConnected() { return connection()->connected(); }
+  bool IsConnected() { return connected(); }
 
  private:
   friend class test::QuicSpdySessionPeer;

--- a/src/net/quic/core/quic_spdy_stream.cc
+++ b/src/net/quic/core/quic_spdy_stream.cc
@@ -142,7 +142,7 @@ void QuicSpdyStream::SetPriority(SpdyPriority priority) {
 }
 
 void QuicSpdyStream::OnStreamHeadersPriority(SpdyPriority priority) {
-  DCHECK_EQ(Perspective::IS_SERVER, session()->connection()->perspective());
+  DCHECK_EQ(Perspective::IS_SERVER, session()->AnyConnection()->perspective());
   SetPriority(priority);
 }
 
@@ -192,7 +192,7 @@ void QuicSpdyStream::OnPromiseHeaderList(
     const QuicHeaderList& /*header_list */) {
   // To be overridden in QuicSpdyClientStream.  Not supported on
   // server side.
-  session()->connection()->CloseConnection(
+  session()->CloseConnection(
       QUIC_INVALID_HEADERS_STREAM_DATA, "Promise headers received by server",
       ConnectionCloseBehavior::SEND_CONNECTION_CLOSE_PACKET);
   return;
@@ -205,14 +205,14 @@ void QuicSpdyStream::OnTrailingHeadersComplete(
   DCHECK(!trailers_decompressed_);
   if (fin_received()) {
     QUIC_DLOG(ERROR) << "Received Trailers after FIN, on stream: " << id();
-    session()->connection()->CloseConnection(
+    session()->CloseConnection(
         QUIC_INVALID_HEADERS_STREAM_DATA, "Trailers after fin",
         ConnectionCloseBehavior::SEND_CONNECTION_CLOSE_PACKET);
     return;
   }
   if (!fin) {
     QUIC_DLOG(ERROR) << "Trailers must have FIN set, on stream: " << id();
-    session()->connection()->CloseConnection(
+    session()->CloseConnection(
         QUIC_INVALID_HEADERS_STREAM_DATA, "Fin missing from trailers",
         ConnectionCloseBehavior::SEND_CONNECTION_CLOSE_PACKET);
     return;
@@ -222,7 +222,7 @@ void QuicSpdyStream::OnTrailingHeadersComplete(
   if (!SpdyUtils::CopyAndValidateTrailers(header_list, &final_byte_offset,
                                           &received_trailers_)) {
     QUIC_DLOG(ERROR) << "Trailers for stream " << id() << " are malformed.";
-    session()->connection()->CloseConnection(
+    session()->CloseConnection(
         QUIC_INVALID_HEADERS_STREAM_DATA, "Trailers are malformed",
         ConnectionCloseBehavior::SEND_CONNECTION_CLOSE_PACKET);
     return;

--- a/src/net/quic/core/quic_stream.cc
+++ b/src/net/quic/core/quic_stream.cc
@@ -49,7 +49,7 @@ QuicStream::PendingData::~PendingData() {}
 
 QuicStream::QuicStream(QuicStreamId id, QuicSession* session)
     : queued_data_bytes_(0),
-      sequencer_(this, session->connection()->clock()),
+      sequencer_(this, session->AnyConnection()->clock()),
       id_(id),
       session_(session),
       stream_bytes_read_(0),
@@ -64,7 +64,7 @@ QuicStream::QuicStream(QuicStreamId id, QuicSession* session)
       rst_sent_(false),
       rst_received_(false),
       perspective_(session_->perspective()),
-      flow_controller_(session_->connection(),
+      flow_controller_(session_->connection_manager(),
                        id_,
                        perspective_,
                        GetReceivedFlowControlWindow(session),
@@ -175,7 +175,7 @@ void QuicStream::Reset(QuicRstStreamErrorCode error) {
 
 void QuicStream::CloseConnectionWithDetails(QuicErrorCode error,
                                             const string& details) {
-  session()->connection()->CloseConnection(
+  session()->CloseConnection(
       error, details, ConnectionCloseBehavior::SEND_CONNECTION_CLOSE_PACKET);
 }
 
@@ -398,16 +398,12 @@ bool QuicStream::HasBufferedData() const {
 }
 
 QuicVersion QuicStream::version() const {
-  return session_->connection()->version();
+  return session_->AnyConnection()->version();
 }
 
 void QuicStream::StopReading() {
   QUIC_DLOG(INFO) << ENDPOINT << "Stop reading from stream " << id();
   sequencer_.StopReading();
-}
-
-const QuicSocketAddress& QuicStream::PeerAddressOfLatestPacket() const {
-  return session_->connection()->last_packet_source_address();
 }
 
 void QuicStream::OnClose() {

--- a/src/net/quic/core/quic_stream.h
+++ b/src/net/quic/core/quic_stream.h
@@ -174,9 +174,6 @@ class QUIC_EXPORT_PRIVATE QuicStream {
   // stop sending stream-level flow-control updates when this end sends FIN.
   virtual void StopReading();
 
-  // Get peer IP of the lastest packet which connection is dealing/delt with.
-  virtual const QuicSocketAddress& PeerAddressOfLatestPacket() const;
-
   // Sends as much of 'data' to the connection as the connection will consume,
   // and then buffers any remaining data in queued_data_.
   // If fin is true: if it is immediately passed on to the session,

--- a/src/net/quic/core/quic_stream_sequencer.cc
+++ b/src/net/quic/core/quic_stream_sequencer.cc
@@ -55,8 +55,7 @@ void QuicStreamSequencer::OnStreamFrame(const QuicStreamFrame& frame) {
   if (result != QUIC_NO_ERROR) {
     string details = QuicStrCat(
         "Stream ", stream_->id(), ": ", QuicErrorCodeToString(result), ": ",
-        error_details, "\nPeer Address: ",
-        stream_->PeerAddressOfLatestPacket().ToString());
+        error_details);
     QUIC_LOG_FIRST_N(WARNING, 50) << QuicErrorCodeToString(result);
     QUIC_LOG_FIRST_N(WARNING, 50) << details;
     stream_->CloseConnectionWithDetails(result, details);

--- a/src/net/quic/core/quic_unacked_packet_map.cc
+++ b/src/net/quic/core/quic_unacked_packet_map.cc
@@ -164,6 +164,15 @@ void QuicUnackedPacketMap::RemoveRetransmittability(
   RemoveRetransmittability(info);
 }
 
+const QuicTransmissionInfo& QuicUnackedPacketMap::ExtractTransmissionInfo(
+    QuicPacketNumber packet_number) {
+  QuicTransmissionInfo* info =
+      &unacked_packets_[packet_number - least_unacked_];
+  QuicTransmissionInfo copy = QuicTransmissionInfo(*info);
+  info->retransmittable_frames = QuicFrames();
+  return copy;
+}
+
 void QuicUnackedPacketMap::IncreaseLargestObserved(
     QuicPacketNumber largest_observed) {
   DCHECK_LE(largest_observed_, largest_observed);

--- a/src/net/quic/core/quic_unacked_packet_map.cc
+++ b/src/net/quic/core/quic_unacked_packet_map.cc
@@ -164,7 +164,7 @@ void QuicUnackedPacketMap::RemoveRetransmittability(
   RemoveRetransmittability(info);
 }
 
-const QuicTransmissionInfo& QuicUnackedPacketMap::ExtractTransmissionInfo(
+QuicTransmissionInfo QuicUnackedPacketMap::ExtractTransmissionInfo(
     QuicPacketNumber packet_number) {
   QuicTransmissionInfo* info =
       &unacked_packets_[packet_number - least_unacked_];

--- a/src/net/quic/core/quic_unacked_packet_map.h
+++ b/src/net/quic/core/quic_unacked_packet_map.h
@@ -140,7 +140,7 @@ class QUIC_EXPORT_PRIVATE QuicUnackedPacketMap {
 
   // Looks up the QuicTransmissionInfo by |packet_number|, creates a copy, removes the
   // QuicTransmissionInfo from the queue and returns the copy.
-  const QuicTransmissionInfo& ExtractTransmissionInfo(QuicPacketNumber packet_number);
+  QuicTransmissionInfo ExtractTransmissionInfo(QuicPacketNumber packet_number);
 
   // Increases the largest observed.  Any packets less or equal to
   // |largest_acked_packet| are discarded if they are only for the RTT purposes.

--- a/src/net/quic/core/quic_unacked_packet_map.h
+++ b/src/net/quic/core/quic_unacked_packet_map.h
@@ -138,6 +138,10 @@ class QUIC_EXPORT_PRIVATE QuicUnackedPacketMap {
   // RemoveRetransmittability.
   void RemoveRetransmittability(QuicPacketNumber packet_number);
 
+  // Looks up the QuicTransmissionInfo by |packet_number|, creates a copy, removes the
+  // QuicTransmissionInfo from the queue and returns the copy.
+  const QuicTransmissionInfo& ExtractTransmissionInfo(QuicPacketNumber packet_number);
+
   // Increases the largest observed.  Any packets less or equal to
   // |largest_acked_packet| are discarded if they are only for the RTT purposes.
   void IncreaseLargestObserved(QuicPacketNumber largest_observed);

--- a/src/net/tools/quic/quic_client_base.cc
+++ b/src/net/tools/quic/quic_client_base.cc
@@ -51,7 +51,9 @@ QuicClientBase::QuicClientBase(const QuicServerId& server_id,
       store_response_(false),
       latest_response_code_(-1) {}
 
-QuicClientBase::~QuicClientBase() {}
+QuicClientBase::~QuicClientBase() {
+  session_->connection_manager()->PrintDebuggingInformation();
+}
 
 void QuicClientBase::OnClose(QuicSpdyStream* stream) {
   DCHECK(stream != nullptr);

--- a/src/net/tools/quic/quic_client_base.h
+++ b/src/net/tools/quic/quic_client_base.h
@@ -221,13 +221,11 @@ class QuicClientBase : public QuicClientPushPromiseIndex::Delegate,
     connected_or_attempting_connect_ = connected_or_attempting_connect;
   }
 
-  QuicPacketWriter* writer() { return writer_.get(); }
+  QuicPacketWriter* writer() { return writer_; }
   void set_writer(QuicPacketWriter* writer) {
-    if (writer_.get() != writer) {
-      writer_.reset(writer);
-    }
+    writer_ = writer;
   }
-  void reset_writer() { writer_.reset(); }
+  void reset_writer() {}
 
   QuicByteCount initial_max_packet_length() {
     return initial_max_packet_length_;
@@ -395,7 +393,8 @@ class QuicClientBase : public QuicClientPushPromiseIndex::Delegate,
   std::unique_ptr<QuicAlarmFactory> alarm_factory_;
 
   // Writer used to actually send packets to the wire. Must outlive |session_|.
-  std::unique_ptr<QuicPacketWriter> writer_;
+  // Not owned. Owned by either the subclass or the session.
+  QuicPacketWriter* writer_;
 
   // Index of pending promised streams. Must outlive |session_|.
   QuicClientPushPromiseIndex push_promise_index_;

--- a/src/net/tools/quic/quic_client_session.cc
+++ b/src/net/tools/quic/quic_client_session.cc
@@ -99,7 +99,7 @@ int QuicClientSession::GetNumReceivedServerConfigUpdates() const {
 
 bool QuicClientSession::ShouldCreateIncomingDynamicStream(QuicStreamId id) {
   DCHECK(!FLAGS_quic_reloadable_flag_quic_refactor_stream_creation);
-  if (!connection()->connected()) {
+  if (!connected()) {
     QUIC_BUG << "ShouldCreateIncomingDynamicStream called when disconnected";
     return false;
   }
@@ -110,7 +110,7 @@ bool QuicClientSession::ShouldCreateIncomingDynamicStream(QuicStreamId id) {
   }
   if (id % 2 != 0) {
     QUIC_LOG(WARNING) << "Received invalid push stream id " << id;
-    connection()->CloseConnection(
+    CloseConnection(
         QUIC_INVALID_STREAM_ID, "Server created odd numbered stream",
         ConnectionCloseBehavior::SEND_CONNECTION_CLOSE_PACKET);
     return false;

--- a/src/net/tools/quic/quic_dispatcher.cc
+++ b/src/net/tools/quic/quic_dispatcher.cc
@@ -508,6 +508,8 @@ void QuicDispatcher::OnConnectionClosed(QuicConnectionId connection_id,
       << ") due to error: " << QuicErrorCodeToString(error)
       << ", with details: " << error_details;
 
+  it->second->connection_manager()->PrintDebuggingInformation();
+
   if (closed_session_list_.empty()) {
     delete_sessions_alarm_->Update(helper()->GetClock()->ApproximateNow(),
                                    QuicTime::Delta::Zero());

--- a/src/net/tools/quic/quic_dispatcher.cc
+++ b/src/net/tools/quic/quic_dispatcher.cc
@@ -481,7 +481,7 @@ bool QuicDispatcher::HasPendingWrites() const {
 void QuicDispatcher::Shutdown() {
   while (!session_map_.empty()) {
     QuicSession* session = session_map_.begin()->second.get();
-    session->connection()->CloseConnection(
+    session->CloseConnection(
         QUIC_PEER_GOING_AWAY, "Server shutdown imminent",
         ConnectionCloseBehavior::SEND_CONNECTION_CLOSE_PACKET);
     // Validate that the session removes itself from the session map on close.
@@ -512,7 +512,8 @@ void QuicDispatcher::OnConnectionClosed(QuicConnectionId connection_id,
     delete_sessions_alarm_->Update(helper()->GetClock()->ApproximateNow(),
                                    QuicTime::Delta::Zero());
   }
-  QuicConnection* connection = it->second->connection();
+  //TODO(cyrill) Maybe add all connections to the time wait list?
+  QuicConnection* connection = it->second->InitialConnection();
   closed_session_list_.push_back(std::move(it->second));
   const bool should_close_statelessly =
       (error == QUIC_CRYPTO_HANDSHAKE_STATELESS_REJECT);

--- a/src/net/tools/quic/quic_multipath_client.cc
+++ b/src/net/tools/quic/quic_multipath_client.cc
@@ -69,6 +69,7 @@ QuicMultipathClient::QuicMultipathClient(QuicSocketAddress server_address,
 }
 
 QuicMultipathClient::~QuicMultipathClient() {
+  session()->connection_manager()->PrintDebuggingInformation();
   if (connected()) {
     session()->CloseConnection(
         QUIC_PEER_GOING_AWAY, "Client being torn down",
@@ -199,6 +200,7 @@ void QuicMultipathClient::OnEvent(int fd, EpollEvent* event) {
   //DCHECK_EQ(fd, GetLatestFD());
 
   if (event->in_events & EPOLLIN) {
+    QUIC_LOG(INFO) << "EPOLLIN";
     bool more_to_read = true;
     while (connected() && more_to_read) {
       more_to_read = packet_reader_->ReadAndDispatchPackets(
@@ -208,6 +210,7 @@ void QuicMultipathClient::OnEvent(int fd, EpollEvent* event) {
     }
   }
   if (connected() && (event->in_events & EPOLLOUT)) {
+    QUIC_LOG(INFO) << "EPOLLOUT";
     fd_to_writer_map_[fd]->SetWritable();
     session()->OnCanWrite(session()->connection_manager()->ConnectionOfSubflow(fd_to_subflow_map_[fd]));
     //session()->OnCanWrite(fd_to_subflow_map_[fd]);

--- a/src/net/tools/quic/quic_multipath_client.cc
+++ b/src/net/tools/quic/quic_multipath_client.cc
@@ -70,7 +70,7 @@ QuicMultipathClient::QuicMultipathClient(QuicSocketAddress server_address,
 
 QuicMultipathClient::~QuicMultipathClient() {
   if (connected()) {
-    session()->connection()->CloseConnection(
+    session()->CloseConnection(
         QUIC_PEER_GOING_AWAY, "Client being torn down",
         ConnectionCloseBehavior::SEND_CONNECTION_CLOSE_PACKET);
   }
@@ -209,7 +209,7 @@ void QuicMultipathClient::OnEvent(int fd, EpollEvent* event) {
   }
   if (connected() && (event->in_events & EPOLLOUT)) {
     fd_to_writer_map_[fd]->SetWritable();
-    session()->OnCanWrite();
+    session()->OnCanWrite(session()->connection_manager()->ConnectionOfSubflow(fd_to_subflow_map_[fd]));
     //session()->OnCanWrite(fd_to_subflow_map_[fd]);
 
     //writer()->SetWritable();

--- a/src/net/tools/quic/quic_multipath_server.cc
+++ b/src/net/tools/quic/quic_multipath_server.cc
@@ -205,6 +205,7 @@ void QuicMultipathServer::OnEvent(int fd, EpollEvent* event) {
     }
   }
   if (event->in_events & EPOLLOUT) {
+    QUIC_DVLOG(1) << "EPOLLOUT";
     //TODO allow multiple outgoing connections -> multiple fds -> multiple writers
     dispatcher_->OnCanWrite();
     if (dispatcher_->HasPendingWrites()) {

--- a/src/net/tools/quic/quic_multipath_server_bin.cc
+++ b/src/net/tools/quic/quic_multipath_server_bin.cc
@@ -17,7 +17,7 @@
 #include "net/quic/core/quic_packets.h"
 #include "net/quic/platform/api/quic_socket_address.h"
 #include "net/tools/quic/quic_http_response_cache.h"
-#include "net/tools/quic/quic_server.h"
+#include "net/tools/quic/quic_multipath_server.h"
 
 // The port the quic server will listen on.
 int32_t FLAGS_port = 6121;
@@ -81,7 +81,7 @@ int main(int argc, char* argv[]) {
   }
 
   net::QuicConfig config;
-  net::QuicServer server(
+  net::QuicMultipathServer server(
       CreateProofSource(line->GetSwitchValuePath("certificate_file"),
                         line->GetSwitchValuePath("key_file")),
       config, net::QuicCryptoServerConfig::ConfigOptions(),

--- a/src/net/tools/quic/quic_simple_dispatcher.cc
+++ b/src/net/tools/quic/quic_simple_dispatcher.cc
@@ -54,7 +54,8 @@ QuicServerSessionBase* QuicSimpleDispatcher::CreateQuicSession(
   QuicConnection* connection = new QuicConnection(
       connection_id, server_address, client_address, helper(), alarm_factory(),
       CreatePerConnectionWriter(),
-      /* owns_writer= */ true, Perspective::IS_SERVER, GetSupportedVersions());
+      /* owns_writer= */ true, Perspective::IS_SERVER, GetSupportedVersions(),
+      kInitialSubflowId);
 
   QuicServerSessionBase* session = new QuicSimpleServerSession(
       config(), connection, this, session_helper(), crypto_config(),

--- a/src/net/tools/quic/quic_simple_server_session.cc
+++ b/src/net/tools/quic/quic_simple_server_session.cc
@@ -35,7 +35,7 @@ QuicSimpleServerSession::QuicSimpleServerSession(
       response_cache_(response_cache) {}
 
 QuicSimpleServerSession::~QuicSimpleServerSession() {
-  delete connection();
+  delete InitialConnection();
 }
 
 QuicCryptoServerStreamBase*
@@ -58,7 +58,7 @@ void QuicSimpleServerSession::StreamDraining(QuicStreamId id) {
 void QuicSimpleServerSession::OnStreamFrame(const QuicStreamFrame& frame) {
   if (!IsIncomingStream(frame.stream_id)) {
     QUIC_LOG(WARNING) << "Client shouldn't send data on server push stream";
-    connection()->CloseConnection(
+    CloseConnection(
         QUIC_INVALID_STREAM_ID, "Client sent data on server push stream",
         ConnectionCloseBehavior::SEND_CONNECTION_CLOSE_PACKET);
     return;
@@ -149,7 +149,7 @@ void QuicSimpleServerSession::HandleRstOnValidNonexistentStream(
     size_t index = (frame.stream_id - next_outgoing_stream_id()) / 2;
     DCHECK(index <= promised_streams_.size());
     promised_streams_[index].is_cancelled = true;
-    connection()->SendRstStream(frame.stream_id, QUIC_RST_ACKNOWLEDGEMENT, 0);
+    connection_manager()->SendRstStream(frame.stream_id, QUIC_RST_ACKNOWLEDGEMENT, 0);
   }
 }
 

--- a/src/net/tools/quic/quic_spdy_client_stream.cc
+++ b/src/net/tools/quic/quic_spdy_client_stream.cc
@@ -130,8 +130,9 @@ void QuicSpdyClientStream::OnDataAvailable() {
 size_t QuicSpdyClientStream::SendRequest(SpdyHeaderBlock headers,
                                          QuicStringPiece body,
                                          bool fin) {
+  //TODO(cyrill) get the correct connection as a parameter instead of InitialConnection()
   QuicConnection::ScopedPacketBundler bundler(
-      session_->connection(), QuicConnection::SEND_ACK_IF_QUEUED);
+      session_->InitialConnection(), QuicConnection::SEND_ACK_IF_QUEUED);
   bool send_fin_with_headers = fin && body.empty();
   size_t bytes_sent = body.size();
   header_bytes_written_ =


### PR DESCRIPTION
Allows sending multiple ACK frames of a specific subflow over different subflows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jpcsmith/proto-quic/3)
<!-- Reviewable:end -->
