### PR TITLE
Cryptostream

### DIFF
--- a/src/net/quic/chromium/quic_chromium_client_session.h
+++ b/src/net/quic/chromium/quic_chromium_client_session.h
@@ -307,7 +307,7 @@ class NET_EXPORT_PRIVATE QuicChromiumClientSession
   void OnHeadersHeadOfLineBlocking(QuicTime::Delta delta) override;
 
   // QuicSession methods:
-  void OnStreamFrame(const QuicStreamFrame& frame) override;
+  void OnStreamFrame(const QuicStreamFrame& frame, QuicConnection* connection) override;
   QuicChromiumClientStream* CreateOutgoingDynamicStream(
       SpdyPriority priority) override;
   const QuicCryptoClientStream* GetCryptoStream() const override;

--- a/src/net/quic/chromium/quic_chromium_client_stream.cc
+++ b/src/net/quic/chromium/quic_chromium_client_stream.cc
@@ -393,7 +393,7 @@ int QuicChromiumClientStream::WriteStreamData(
   // We should not have data buffered.
   DCHECK(!HasBufferedData());
   // Writes the data, or buffers it.
-  WriteOrBufferData(data, fin, nullptr);
+  WriteOrBufferData(data, fin, nullptr, nullptr);
   if (!HasBufferedData()) {
     return OK;
   }
@@ -413,7 +413,7 @@ int QuicChromiumClientStream::WritevStreamData(
   for (size_t i = 0; i < buffers.size(); ++i) {
     bool is_fin = fin && (i == buffers.size() - 1);
     QuicStringPiece string_data(buffers[i]->data(), lengths[i]);
-    WriteOrBufferData(string_data, is_fin, nullptr);
+    WriteOrBufferData(string_data, is_fin, nullptr, nullptr);
   }
   if (!HasBufferedData()) {
     return OK;

--- a/src/net/quic/chromium/quic_stream_factory.cc
+++ b/src/net/quic/chromium/quic_stream_factory.cc
@@ -1649,7 +1649,9 @@ void QuicStreamFactory::InitializeCachedStateInCryptoConfig(
   if (!server_info || !server_info->Load())
     return;
 
-  cached->Initialize(server_info->state().server_config,
+  // Not used, so we can send invalid (nullptr) QuicConnection object.
+  cached->Initialize(nullptr,
+                     server_info->state().server_config,
                      server_info->state().source_address_token,
                      server_info->state().certs, server_info->state().cert_sct,
                      server_info->state().chlo_hash,

--- a/src/net/quic/core/crypto/crypto_framer.cc
+++ b/src/net/quic/core/crypto/crypto_framer.cc
@@ -267,6 +267,7 @@ QuicErrorCode CryptoFramer::Process(QuicStringPiece input,
         reader.ReadStringPiece(&value, item.second);
         message_.SetStringPiece(item.first, value);
       }
+      message_.SetConnection(process_connection_);
       visitor_->OnHandshakeMessage(message_);
       Clear();
       state_ = STATE_READING_TAG;

--- a/src/net/quic/core/crypto/crypto_framer.h
+++ b/src/net/quic/core/crypto/crypto_framer.h
@@ -55,6 +55,9 @@ class QUIC_EXPORT_PRIVATE CryptoFramer {
     visitor_ = visitor;
   }
 
+  void set_process_connection(QuicConnection* connection) {
+    process_connection_ = connection; }
+
   QuicErrorCode error() const { return error_; }
   const std::string& error_detail() const { return error_detail_; }
 
@@ -111,6 +114,8 @@ class QUIC_EXPORT_PRIVATE CryptoFramer {
   std::vector<std::pair<QuicTag, size_t>> tags_and_lengths_;
   // Cumulative length of all values in the message currently being parsed.
   size_t values_len_;
+  // The last call to Process() was made for a frame sent on this connection;
+  QuicConnection* process_connection_;
 };
 
 }  // namespace net

--- a/src/net/quic/core/crypto/crypto_handshake_message.cc
+++ b/src/net/quic/core/crypto/crypto_handshake_message.cc
@@ -26,7 +26,8 @@ CryptoHandshakeMessage::CryptoHandshakeMessage(
     const CryptoHandshakeMessage& other)
     : tag_(other.tag_),
       tag_value_map_(other.tag_value_map_),
-      minimum_size_(other.minimum_size_) {
+      minimum_size_(other.minimum_size_),
+      connection_(other.connection_) {
   // Don't copy serialized_. unique_ptr doesn't have a copy constructor.
   // The new object can lazily reconstruct serialized_.
 }
@@ -40,6 +41,7 @@ CryptoHandshakeMessage& CryptoHandshakeMessage::operator=(
     const CryptoHandshakeMessage& other) {
   tag_ = other.tag_;
   tag_value_map_ = other.tag_value_map_;
+  connection_ = other.connection_;
   // Don't copy serialized_. unique_ptr doesn't have an assignment operator.
   // However, invalidate serialized_.
   serialized_.reset();

--- a/src/net/quic/core/crypto/crypto_handshake_message.h
+++ b/src/net/quic/core/crypto/crypto_handshake_message.h
@@ -17,6 +17,8 @@
 
 namespace net {
 
+class QuicConnection;
+
 // An intermediate format of a handshake message that's convenient for a
 // CryptoFramer to serialize from or parse into.
 class QUIC_EXPORT_PRIVATE CryptoHandshakeMessage {
@@ -28,6 +30,11 @@ class QUIC_EXPORT_PRIVATE CryptoHandshakeMessage {
 
   CryptoHandshakeMessage& operator=(const CryptoHandshakeMessage& other);
   CryptoHandshakeMessage& operator=(CryptoHandshakeMessage&& other);
+
+  void SetConnection(QuicConnection* connection) {
+    connection_ = connection;
+  }
+  QuicConnection* Connection() const { return connection_; }
 
   // Clears state.
   void Clear();
@@ -128,6 +135,9 @@ class QUIC_EXPORT_PRIVATE CryptoHandshakeMessage {
   QuicTagValueMap tag_value_map_;
 
   size_t minimum_size_;
+
+  // The connection on which this message was received or will be sent.
+  QuicConnection* connection_;
 
   // The serialized form of the handshake message. This member is constructed
   // lasily.

--- a/src/net/quic/core/crypto/quic_crypto_client_config.h
+++ b/src/net/quic/core/crypto/quic_crypto_client_config.h
@@ -28,6 +28,7 @@ class CryptoHandshakeMessage;
 class ProofVerifier;
 class ProofVerifyDetails;
 class QuicRandom;
+class QuicConnection;
 
 // QuicCryptoClientConfig contains crypto-related configuration settings for a
 // client. Note that this object isn't thread-safe. It's designed to be used on
@@ -107,7 +108,7 @@ class QUIC_EXPORT_PRIVATE QuicCryptoClientConfig : public QuicCryptoConfig {
     void SetProofInvalid();
 
     const std::string& server_config() const;
-    const std::string& source_address_token() const;
+    const std::string& source_address_token(QuicConnection* connection) const;
     const std::vector<std::string>& certs() const;
     const std::string& cert_sct() const;
     const std::string& chlo_hash() const;
@@ -116,7 +117,8 @@ class QUIC_EXPORT_PRIVATE QuicCryptoClientConfig : public QuicCryptoConfig {
     uint64_t generation_counter() const;
     const ProofVerifyDetails* proof_verify_details() const;
 
-    void set_source_address_token(QuicStringPiece token);
+    void set_source_address_token(QuicConnection* connection,
+        QuicStringPiece token);
 
     void set_cert_sct(QuicStringPiece cert_sct);
 
@@ -157,7 +159,8 @@ class QUIC_EXPORT_PRIVATE QuicCryptoClientConfig : public QuicCryptoConfig {
 
     // Initializes this cached state based on the arguments provided.
     // Returns false if there is a problem parsing the server config.
-    bool Initialize(QuicStringPiece server_config,
+    bool Initialize(QuicConnection* connection,
+                    QuicStringPiece server_config,
                     QuicStringPiece source_address_token,
                     const std::vector<std::string>& certs,
                     const std::string& cert_sct,
@@ -168,7 +171,8 @@ class QUIC_EXPORT_PRIVATE QuicCryptoClientConfig : public QuicCryptoConfig {
 
    private:
     std::string server_config_;         // A serialized handshake message.
-    std::string source_address_token_;  // An opaque proof of IP ownership.
+    std::map<QuicConnection*, std::string> source_address_tokens_; // An opaque
+                                        // proof of IP ownership.
     std::vector<std::string> certs_;    // A list of certificates in leaf-first
                                         // order.
     std::string cert_sct_;              // Signed timestamp of the leaf cert.

--- a/src/net/quic/core/crypto/quic_crypto_client_config.h
+++ b/src/net/quic/core/crypto/quic_crypto_client_config.h
@@ -108,7 +108,7 @@ class QUIC_EXPORT_PRIVATE QuicCryptoClientConfig : public QuicCryptoConfig {
     void SetProofInvalid();
 
     const std::string& server_config() const;
-    const std::string& source_address_token(QuicConnection* connection) const;
+    std::string source_address_token(QuicConnection* connection) const;
     const std::vector<std::string>& certs() const;
     const std::string& cert_sct() const;
     const std::string& chlo_hash() const;
@@ -239,7 +239,8 @@ class QUIC_EXPORT_PRIVATE QuicCryptoClientConfig : public QuicCryptoConfig {
       QuicRandom* rand,
       bool demand_x509_proof,
       QuicReferenceCountedPointer<QuicCryptoNegotiatedParameters> out_params,
-      CryptoHandshakeMessage* out) const;
+      CryptoHandshakeMessage* out,
+      QuicConnection* connection) const;
 
   // FillClientHello sets |out| to be a CHLO message based on the configuration
   // of this object. This object must have cached enough information about
@@ -265,7 +266,8 @@ class QUIC_EXPORT_PRIVATE QuicCryptoClientConfig : public QuicCryptoConfig {
       const ChannelIDKey* channel_id_key,
       QuicReferenceCountedPointer<QuicCryptoNegotiatedParameters> out_params,
       CryptoHandshakeMessage* out,
-      std::string* error_details) const;
+      std::string* error_details,
+      QuicConnection* connection) const;
 
   // ProcessRejection processes a REJ message from a server and updates the
   // cached information about that server. After this, |IsComplete| may return

--- a/src/net/quic/core/crypto/quic_crypto_server_config.cc
+++ b/src/net/quic/core/crypto/quic_crypto_server_config.cc
@@ -770,6 +770,9 @@ void QuicCryptoServerConfig::ProcessClientHelloAfterGetProof(
   }
 
   std::unique_ptr<CryptoHandshakeMessage> out(new CryptoHandshakeMessage);
+  // Always set the connection even for a reject so that the server hello
+  // can be sent back on the correct subflow.
+  out->SetConnection(validate_chlo_result.client_hello.Connection());
   if (!info.reject_reasons.empty() || !requested_config.get()) {
     BuildRejection(version, clock->WallNow(), *primary_config, client_hello,
                    info, validate_chlo_result.cached_network_params,

--- a/src/net/quic/core/quic_config.cc
+++ b/src/net/quic/core/quic_config.cc
@@ -97,7 +97,6 @@ QuicErrorCode QuicNegotiableUint32::ProcessPeerHello(
     const CryptoHandshakeMessage& peer_hello,
     HelloType hello_type,
     string* error_details) {
-  DCHECK(!negotiated());
   DCHECK(error_details != nullptr);
   uint32_t value;
   QuicErrorCode error = ReadUint32(peer_hello, tag_, presence_, default_value_,

--- a/src/net/quic/core/quic_connection_manager.h
+++ b/src/net/quic/core/quic_connection_manager.h
@@ -27,7 +27,7 @@ public:
   virtual ~QuicConnectionManagerVisitorInterface() {}
 
   // A simple visitor interface for dealing with a data frame.
-  virtual void OnStreamFrame(const QuicStreamFrame& frame) = 0;
+  virtual void OnStreamFrame(const QuicStreamFrame& frame, QuicConnection* connection) = 0;
 
   // The session should process the WINDOW_UPDATE frame, adjusting both stream
   // and connection level flow control windows.
@@ -91,6 +91,9 @@ public:
   // Called to ask if any streams are open in this visitor, excluding the
   // reserved crypto and headers stream.
   virtual bool HasOpenDynamicStreams() const = 0;
+
+  // Called to start sending crypto handshakes on this connection.
+  virtual void StartCryptoConnect(QuicConnection* connection) = 0;
 };
 
 class QUIC_EXPORT_PRIVATE QuicConnectionManager: public QuicConnectionVisitorInterface {
@@ -167,7 +170,8 @@ public:
       QuicIOVector iov,
       QuicStreamOffset offset,
       StreamSendingState state,
-      QuicReferenceCountedPointer<QuicAckListenerInterface> ack_listener);
+      QuicReferenceCountedPointer<QuicAckListenerInterface> ack_listener,
+      QuicConnection* connection);
   virtual void SendRstStream(QuicStreamId id,
                              QuicRstStreamErrorCode error,
                              QuicStreamOffset bytes_written);

--- a/src/net/quic/core/quic_connection_manager.h
+++ b/src/net/quic/core/quic_connection_manager.h
@@ -194,152 +194,67 @@ public:
   // Called when the CryptoHandshakeEvent HANDSHAKE_CONFIRMED was received.
   void OnHandshakeComplete();
 
-  // QuicSubflowCreationAttemptDelegate
-  //void OnSubflowCreationFailed(QuicSubflowId id) override;
-
   // QuicConnectionVisitorInterface
-  void OnStreamFrame(const QuicSubflowId& subflowId, const QuicStreamFrame& frame) override;
-  void OnWindowUpdateFrame(const QuicSubflowId& subflowId, const QuicWindowUpdateFrame& frame) override;
-  void OnBlockedFrame(const QuicSubflowId& subflowId, const QuicBlockedFrame& frame) override;
-  void OnRstStream(const QuicSubflowId& subflowId, const QuicRstStreamFrame& frame) override;
-  void OnGoAway(const QuicSubflowId& subflowId, const QuicGoAwayFrame& frame) override;
-  void OnConnectionClosed(const QuicSubflowId& subflowId,
+  void OnStreamFrame(QuicConnection* connection, const QuicStreamFrame& frame) override;
+  void OnWindowUpdateFrame(QuicConnection* connection, const QuicWindowUpdateFrame& frame) override;
+  void OnBlockedFrame(QuicConnection* connection, const QuicBlockedFrame& frame) override;
+  void OnRstStream(QuicConnection* connection, const QuicRstStreamFrame& frame) override;
+  void OnGoAway(QuicConnection* connection, const QuicGoAwayFrame& frame) override;
+  void OnConnectionClosed(QuicConnection* connection,
                                   QuicErrorCode error,
                                   const std::string& error_details,
                                   ConnectionCloseSource source) override;
-  void OnWriteBlocked(const QuicSubflowId& subflowId) override;
-  void OnSuccessfulVersionNegotiation(const QuicSubflowId& subflowId, const QuicVersion& version) override;
-  void OnCanWrite(const QuicSubflowId& subflowId) override;
-  void OnCongestionWindowChange(const QuicSubflowId& subflowId, QuicTime now) override;
-  void OnConnectionMigration(const QuicSubflowId& subflowId, PeerAddressChangeType type) override;
-  void OnPathDegrading(const QuicSubflowId& subflowId) override;
-  void PostProcessAfterData(const QuicSubflowId& subflowId) override;
-  void OnAckNeedsRetransmittableFrame(const QuicSubflowId& subflowId) override;
-  bool WillingAndAbleToWrite(const QuicSubflowId& subflowId) const override;
-  bool HasPendingHandshake(const QuicSubflowId& subflowId) const override;
-  bool HasOpenDynamicStreams(const QuicSubflowId& subflowId) const override;
-  bool OnAckFrame(const QuicSubflowId& subflowId, const QuicAckFrame& frame, const QuicTime& arrival_time_of_packet) override;
-  void OnSubflowCloseFrame(const QuicSubflowId& subflowId, const QuicSubflowCloseFrame& frame) override;
+  void OnWriteBlocked(QuicConnection* connection) override;
+  void OnSuccessfulVersionNegotiation(QuicConnection* connection, const QuicVersion& version) override;
+  void OnCanWrite(QuicConnection* connection) override;
+  void OnCongestionWindowChange(QuicConnection* connection, QuicTime now) override;
+  void OnConnectionMigration(QuicConnection* connection, PeerAddressChangeType type) override;
+  void OnPathDegrading(QuicConnection* connection) override;
+  void PostProcessAfterData(QuicConnection* connection) override;
+  void OnAckNeedsRetransmittableFrame(QuicConnection* connection) override;
+  bool WillingAndAbleToWrite(QuicConnection* connection) const override;
+  bool HasPendingHandshake(QuicConnection* connection) const override;
+  bool HasOpenDynamicStreams(QuicConnection* connection) const override;
+  bool OnAckFrame(QuicConnection* connection, const QuicAckFrame& frame, const QuicTime& arrival_time_of_packet) override;
+  void OnNewSubflowFrame(QuicConnection* connection, const QuicNewSubflowFrame& frame) override;
+  void OnSubflowCloseFrame(QuicConnection* connection, const QuicSubflowCloseFrame& frame) override;
   void OnRetransmission(const QuicTransmissionInfo& transmission_info) override;
-  QuicFrames GetUpdatedAckFrames(const QuicSubflowId& subflow_id) override;
-
-
-
-
-  /*class QUIC_EXPORT_PRIVATE QuicSubflowCreationAttempt : public QuicAlarm::Delegate {
-  public:
-    const size_t kSubflowCreationTimeout = 1000;
-
-    class QUIC_EXPORT_PRIVATE QuicSubflowCreationAttemptDelegate {
-      virtual void OnSubflowCreationFailed(QuicSubflowId id) = 0;
-    };
-
-    QuicSubflowCreationAttempt(QuicSubflowDescriptor descriptor,
-        QuicSubflowId subflow_id,
-        QuicSubflowCreationAttemptDelegate *visitor,
-        QuicClock *clock,
-        QuicAlarmFactory *alarmFactory) :
-          descriptor_(descriptor),
-          subflow_id_(subflow_id),
-          last_attempt_time_(clock->ApproximateNow()),
-          n_attempts_(1),
-          visitor_(visitor)
-    {
-      alarm_ = alarmFactory->CreateAlarm(this);
-      alarm_->Set(last_attempt_time_+kSubflowCreationTimeout);
-    }
-
-    ~QuicSubflowCreationAttempt() {
-      delete alarm_;
-    }
-
-    void OnAlarm() override {
-      visitor_->OnSubflowCreationFailed(subflow_id_);
-    }
-
-  private:
-    QuicSubflowDescriptor descriptor_;
-    QuicSubflowId subflow_id_;
-    QuicTime last_attempt_time_;
-    size_t n_attempts_;
-    QuicSubflowCreationAttemptDelegate *visitor_;
-    QuicAlarm *alarm_;
-
-    DISALLOW_COPY_AND_ASSIGN(QuicSubflowCreationAttempt);
-  };*/
-
-protected:
+  QuicFrames GetUpdatedAckFrames(QuicConnection* connection) override;
 
 private:
-  class QUIC_EXPORT_PRIVATE QuicSubflowPacketHandler : public QuicFramerVisitorInterface {
-  public:
-    QuicSubflowPacketHandler(
-        const QuicVersionVector& supported_versions,
-        QuicTime creation_time,
-        Perspective perspective,
-        QuicFramerCryptoContext *cc,
-        bool owns_cc,
-        QuicVersion version)
-    : framer_(supported_versions, creation_time, perspective, cc, owns_cc, version) {
-      framer_.set_visitor(this);
-    }
-    ~QuicSubflowPacketHandler() override {}
-
-    // Processes a packet from a new subflow and checks whether there is exactly
-    // one NEW_SUBFLOW frame.
-    bool ProcessPacket(const QuicReceivedPacket& packet) {
-      n_new_subflow_frames_ = 0;
-      if(!framer_.ProcessPacket(packet)) {
-        //TODO error handling
-        return false;
-      }
-
-      return n_new_subflow_frames_ == 1;
-    }
-    QuicSubflowId GetLastSubflowId() {
-      return subflow_id_;
-    }
-
-    void OnPacket() override;
-    bool OnUnauthenticatedPublicHeader(
-        const QuicPacketPublicHeader& header) override;
-    bool OnUnauthenticatedHeader(const QuicPacketHeader& header) override;
-    void OnError(QuicFramer* framer) override;
-    bool OnProtocolVersionMismatch(QuicVersion received_version) override; //TODO is this possible?
-    void OnPublicResetPacket(const QuicPublicResetPacket& packet) override;
-    void OnVersionNegotiationPacket(
-        const QuicVersionNegotiationPacket& packet) override;
-    void OnDecryptedPacket(EncryptionLevel level) override;
-    bool OnPacketHeader(const QuicPacketHeader& header) override;
-    bool OnStreamFrame(const QuicStreamFrame& frame) override;
-    bool OnAckFrame(const QuicAckFrame& frame) override;
-    bool OnStopWaitingFrame(const QuicStopWaitingFrame& frame) override;
-    bool OnPaddingFrame(const QuicPaddingFrame& frame) override;
-    bool OnPingFrame(const QuicPingFrame& frame) override;
-    bool OnRstStreamFrame(const QuicRstStreamFrame& frame) override;
-    bool OnConnectionCloseFrame(const QuicConnectionCloseFrame& frame) override;
-    bool OnGoAwayFrame(const QuicGoAwayFrame& frame) override;
-    bool OnWindowUpdateFrame(const QuicWindowUpdateFrame& frame) override;
-    bool OnBlockedFrame(const QuicBlockedFrame& frame) override;
-    bool OnNewSubflowFrame(const QuicNewSubflowFrame& frame) override;
-    bool OnSubflowCloseFrame(const QuicSubflowCloseFrame& frame) override;
-    void OnPacketComplete() override;
-  private:
-    QuicFramer framer_;
-    QuicSubflowId subflow_id_;
-    int n_new_subflow_frames_;
-
-    DISALLOW_COPY_AND_ASSIGN(QuicSubflowPacketHandler);
-  };
 
   enum SubflowDirection {
     SUBFLOW_OUTGOING,
     SUBFLOW_INCOMING
   };
-  void OpenConnection(QuicSubflowDescriptor descriptor, QuicSubflowId subflowId, SubflowDirection direction);
+
+  void AckReceivedForSubflow(QuicConnection* connection, const QuicAckFrame& frame);
+
+  // Creates a QuicConnection object for the specified subflow descriptor.
+  void OpenConnection(QuicSubflowDescriptor descriptor, SubflowDirection direction);
+
+  // Assigns a specific subflow id to a subflow.
+  void AssignConnection(QuicSubflowDescriptor descriptor, QuicSubflowId subflowId, SubflowDirection direction);
+
+  // Adds the QuicConnection object to the connections_ and subflow_descriptor_map_ map.
   void AddConnection(QuicSubflowDescriptor descriptor, QuicSubflowId subflowId, QuicConnection *connection);
-  void CloseConnection(QuicSubflowId subflowId, SubflowDirection direction);
+
+  // Removes the connection from the connections_ and subflow_descriptor_map_ map.
   void RemoveConnection(QuicSubflowId subflowId);
+
+  // Adds the connection to the unassigned_subflow_map_ map.
+  void AddUnassignedConnection(QuicSubflowDescriptor descriptor, QuicConnection *connection);
+
+  // Removes the connection from the unassigned_subflow_map_ map.
+  void RemoveUnassignedConnection(QuicSubflowDescriptor descriptor);
+
+  // If direction == SUBFLOW_INCOMING the peer initiated the closing and we
+  // received a SUBFLOW_CLOSE frame for this subflow.
+  // If direction == SUBFLOW_OUTGOING then we initiated the closing and start
+  // sending SUBFLOW_CLOSE frame.
+  void CloseConnection(QuicSubflowId subflowId, SubflowDirection direction);
+
+  bool IsSubflowIdValid(QuicSubflowId subflowId, SubflowDirection direction, std::string* detailed_error);
 
   // Create packet writer for new connections
   QuicPacketWriter *GetPacketWriter(QuicSubflowDescriptor descriptor);
@@ -347,8 +262,9 @@ private:
   void InitializeSubflowPacketHandler();
 
   QuicSubflowId GetNextOutgoingSubflowId();
-  bool IsValidIncomingSubflowId(QuicSubflowId id);
-  bool IsValidOutgoingSubflowId(QuicSubflowId id);
+
+  QuicConnection* GetConnection(QuicSubflowId subflowId) const;
+  QuicConnection* GetConnection(const QuicSubflowDescriptor& subflowId) const;
 
   QuicConnectionManagerVisitorInterface *visitor_;
 
@@ -363,17 +279,12 @@ private:
 
   std::map<QuicSubflowDescriptor, QuicSubflowId> subflow_descriptor_map_;
 
-  // A set of all subflows where a connection attempt was made.
-  std::set<QuicSubflowDescriptor> buffered_outgoing_subflow_attempts_;
-  // A set of buffered packets with their corresponding QuicSubflowDescriptor
-  std::vector<std::pair<QuicSubflowDescriptor, std::unique_ptr<QuicReceivedPacket>> > buffered_incoming_subflow_attempts_;
+  // Stores the connections with incoming handshake messages that did not yet
+  // send a NEW_SUBFLOW frame (using a 0-RTT or 1-RTT packet).
+  std::map<QuicSubflowDescriptor, QuicConnection*> unassigned_subflow_map_;
 
   // The ID to use for the next outgoing subflow.
   QuicSubflowId next_outgoing_subflow_id_;
-
-  // QuicFramer wrapper class for reading packets that do not belong to
-  // a connection. (Packets on new subflows)
-  QuicSubflowPacketHandler *packet_handler_;
 
   std::map<QuicSubflowDescriptor, QuicPacketWriter*> packet_writer_map_;
 
@@ -382,12 +293,6 @@ private:
 
   // The subflow that will be used as the current subflow as soon as it is open.
   QuicSubflowId next_subflow_id_;
-
-  /*std::map<QuicSubflowDescriptor, QuicSubflowCreationAttempt> subflow_attempt_map_;
-
-  // helper classes
-  QuicClock *clock_;
-  QuicAlarmFactory *alarm_factory_;*/
 
   DISALLOW_COPY_AND_ASSIGN(QuicConnectionManager);
 };

--- a/src/net/quic/core/quic_crypto_client_stream.cc
+++ b/src/net/quic/core/quic_crypto_client_stream.cc
@@ -27,59 +27,59 @@ const int QuicCryptoClientStream::kMaxClientHellos;
 QuicCryptoClientStreamBase::QuicCryptoClientStreamBase(QuicSession* session)
     : QuicCryptoStream(session) {}
 
-QuicCryptoClientStream::ChannelIDSourceCallbackImpl::
-    ChannelIDSourceCallbackImpl(QuicCryptoClientStream* stream)
-    : stream_(stream) {}
+QuicCryptoClientStream::QuicCryptoClientStreamConnectionState::ChannelIDSourceCallbackImpl::
+    ChannelIDSourceCallbackImpl(QuicCryptoClientStreamConnectionState* connection_state)
+    : connection_state_(connection_state) {}
 
-QuicCryptoClientStream::ChannelIDSourceCallbackImpl::
+QuicCryptoClientStream::QuicCryptoClientStreamConnectionState::ChannelIDSourceCallbackImpl::
     ~ChannelIDSourceCallbackImpl() {}
 
-void QuicCryptoClientStream::ChannelIDSourceCallbackImpl::Run(
+void QuicCryptoClientStream::QuicCryptoClientStreamConnectionState::ChannelIDSourceCallbackImpl::Run(
     std::unique_ptr<ChannelIDKey>* channel_id_key) {
-  if (stream_ == nullptr) {
+  if (connection_state_ == nullptr) {
     return;
   }
 
-  stream_->channel_id_key_ = std::move(*channel_id_key);
-  stream_->channel_id_source_callback_run_ = true;
-  stream_->channel_id_source_callback_ = nullptr;
-  stream_->DoHandshakeLoop(nullptr);
+  connection_state_->channel_id_key_ = std::move(*channel_id_key);
+  connection_state_->channel_id_source_callback_run_ = true;
+  connection_state_->channel_id_source_callback_ = nullptr;
+  connection_state_->GetChannelIdComplete();
 
   // The ChannelIDSource owns this object and will delete it when this method
   // returns.
 }
 
-void QuicCryptoClientStream::ChannelIDSourceCallbackImpl::Cancel() {
-  stream_ = nullptr;
+void QuicCryptoClientStream::QuicCryptoClientStreamConnectionState::ChannelIDSourceCallbackImpl::Cancel() {
+  connection_state_ = nullptr;
 }
 
-QuicCryptoClientStream::ProofVerifierCallbackImpl::ProofVerifierCallbackImpl(
-    QuicCryptoClientStream* stream)
-    : stream_(stream) {}
+QuicCryptoClientStream::QuicCryptoClientStreamConnectionState::ProofVerifierCallbackImpl::ProofVerifierCallbackImpl(
+    QuicCryptoClientStreamConnectionState* connection_state)
+    : connection_state_(connection_state) {}
 
-QuicCryptoClientStream::ProofVerifierCallbackImpl::
+QuicCryptoClientStream::QuicCryptoClientStreamConnectionState::ProofVerifierCallbackImpl::
     ~ProofVerifierCallbackImpl() {}
 
-void QuicCryptoClientStream::ProofVerifierCallbackImpl::Run(
+void QuicCryptoClientStream::QuicCryptoClientStreamConnectionState::ProofVerifierCallbackImpl::Run(
     bool ok,
     const string& error_details,
     std::unique_ptr<ProofVerifyDetails>* details) {
-  if (stream_ == nullptr) {
+  if (connection_state_ == nullptr) {
     return;
   }
 
-  stream_->verify_ok_ = ok;
-  stream_->verify_error_details_ = error_details;
-  stream_->verify_details_ = std::move(*details);
-  stream_->proof_verify_callback_ = nullptr;
-  stream_->DoHandshakeLoop(nullptr);
+  connection_state_->verify_ok_ = ok;
+  connection_state_->verify_error_details_ = error_details;
+  connection_state_->verify_details_ = std::move(*details);
+  connection_state_->proof_verify_callback_ = nullptr;
+  connection_state_->ProofVerifyComplete();
 
   // The ProofVerifier owns this object and will delete it when this method
   // returns.
 }
 
-void QuicCryptoClientStream::ProofVerifierCallbackImpl::Cancel() {
-  stream_ = nullptr;
+void QuicCryptoClientStream::QuicCryptoClientStreamConnectionState::ProofVerifierCallbackImpl::Cancel() {
+  connection_state_ = nullptr;
 }
 
 QuicCryptoClientStream::QuicCryptoClientStream(
@@ -89,24 +89,93 @@ QuicCryptoClientStream::QuicCryptoClientStream(
     QuicCryptoClientConfig* crypto_config,
     ProofHandler* proof_handler)
     : QuicCryptoClientStreamBase(session),
-      next_state_(STATE_IDLE),
-      num_client_hellos_(0),
-      crypto_config_(crypto_config),
-      server_id_(server_id),
-      generation_counter_(0),
-      channel_id_sent_(false),
-      channel_id_source_callback_run_(false),
-      channel_id_source_callback_(nullptr),
-      verify_context_(verify_context),
-      proof_verify_callback_(nullptr),
-      proof_handler_(proof_handler),
-      verify_ok_(false),
-      stateless_reject_received_(false),
-      num_scup_messages_received_(0) {
+      crypto_config_(crypto_config) {
   DCHECK_EQ(Perspective::IS_CLIENT, session->AnyConnection()->perspective());
+  AddConnectionState(session->connection_manager()->InitialConnection(),
+      verify_context,server_id,proof_handler);
 }
 
-QuicCryptoClientStream::~QuicCryptoClientStream() {
+QuicCryptoClientStream::~QuicCryptoClientStream() {}
+
+void QuicCryptoClientStream::OnHandshakeMessage(
+    const CryptoHandshakeMessage& message) {
+  QuicCryptoClientStreamBase::OnHandshakeMessage(message);
+
+  if(connection_states_.find(connection) == connection_states_.end()) {
+    AddConnectionState(connection);
+  }
+
+  DCHECK(connection_states_.find(message.Connection()) != connection_states_.end());
+  QuicCryptoClientStreamConnectionState* cs = connection_states_[message.Connection()];
+
+  if (message.tag() == kSCUP) {
+    if (!cs->handshake_confirmed()) {
+      CloseConnectionWithDetails(QUIC_CRYPTO_UPDATE_BEFORE_HANDSHAKE_COMPLETE,
+                                 "Early SCUP disallowed");
+      return;
+    }
+
+    // |message| is an update from the server, so we treat it differently from a
+    // handshake message.
+    HandleServerConfigUpdateMessage(cs,message);
+    cs->num_scup_messages_received_++;
+    return;
+  }
+
+  // Do not process handshake messages after the handshake is confirmed.
+  if (cs->handshake_confirmed()) {
+    CloseConnectionWithDetails(QUIC_CRYPTO_MESSAGE_AFTER_HANDSHAKE_COMPLETE,
+                               "Unexpected handshake message");
+    return;
+  }
+
+  DoHandshakeLoop(cs, &message);
+}
+
+void QuicCryptoClientStream::AddConnectionState(QuicConnection* connection) {
+  // Create a new state for this connection using the same privacy mode but
+  // adjust the server address for the new connection (the server address
+  // might be different since we allow multipathing).
+  QuicCryptoClientStreamConnectionState* anyCS = connection_states_.begin()->second;
+  QuicServerId sid(connection->SubflowDescriptor().Peer(),anyCS->server_id_.privacy_mode());
+  AddConnectionState(connection, anyCS->verify_context_, sid, anyCS->proof_handler_);
+}
+
+void QuicCryptoClientStream::AddConnectionState(QuicConnection* connection,
+                        ProofVerifyContext* verify_context,
+                        const QuicServerId& server_id,
+                        ProofHandler* proof_handler) {
+  QuicCryptoStream::AddConnectionState(connection,
+      new QuicCryptoClientStreamConnectionState(
+          connection, verify_context, server_id, proof_handler, this));
+}
+
+QuicCryptoClientStream::QuicCryptoClientStreamConnectionState::
+QuicCryptoClientStreamConnectionState(
+                QuicConnection* connection,
+                ProofVerifyContext* verify_context,
+                const QuicServerId& server_id,
+                ProofHandler* proof_handler,
+                QuicCryptoClientStream* stream) :
+  QuicCryptoStreamConnectionState(connection),
+  next_state_(STATE_IDLE),
+  num_client_hellos_(0),
+  server_id_(server_id),
+  generation_counter_(0),
+  channel_id_sent_(false),
+  channel_id_source_callback_run_(false),
+  channel_id_source_callback_(nullptr),
+  verify_context_(verify_context),
+  proof_verify_callback_(nullptr),
+  proof_handler_(proof_handler),
+  verify_ok_(false),
+  stateless_reject_received_(false),
+  num_scup_messages_received_(0),
+  stream_(stream) {
+}
+
+QuicCryptoClientStream::QuicCryptoClientStreamConnectionState::
+~QuicCryptoClientStreamConnectionState() {
   if (channel_id_source_callback_) {
     channel_id_source_callback_->Cancel();
   }
@@ -115,67 +184,36 @@ QuicCryptoClientStream::~QuicCryptoClientStream() {
   }
 }
 
-void QuicCryptoClientStream::OnHandshakeMessage(
-    const CryptoHandshakeMessage& message) {
-  QuicCryptoClientStreamBase::OnHandshakeMessage(message);
-
-  if (message.tag() == kSCUP) {
-    if (!handshake_confirmed()) {
-      CloseConnectionWithDetails(QUIC_CRYPTO_UPDATE_BEFORE_HANDSHAKE_COMPLETE,
-                                 "Early SCUP disallowed");
-      return;
-    }
-
-    // |message| is an update from the server, so we treat it differently from a
-    // handshake message.
-    HandleServerConfigUpdateMessage(message);
-    num_scup_messages_received_++;
-    return;
+bool QuicCryptoClientStream::CryptoConnect(QuicConnection* connection) {
+  QuicCryptoClientStreamConnectionState* cs;
+  if(connection_states_.find(connection) == connection_states_.end()) {
+    AddConnectionState(connection);
   }
-
-  // Do not process handshake messages after the handshake is confirmed.
-  if (handshake_confirmed()) {
-    CloseConnectionWithDetails(QUIC_CRYPTO_MESSAGE_AFTER_HANDSHAKE_COMPLETE,
-                               "Unexpected handshake message");
-    return;
-  }
-
-  DoHandshakeLoop(&message);
-}
-
-bool QuicCryptoClientStream::CryptoConnect() {
-  next_state_ = STATE_INITIALIZE;
-  DoHandshakeLoop(nullptr);
+  cs = connection_states_[connection];
+  cs->next_state_ = STATE_INITIALIZE;
+  DoHandshakeLoop(cs, nullptr);
   return session()->connected();
 }
 
 int QuicCryptoClientStream::num_sent_client_hellos() const {
-  return num_client_hellos_;
+  return connection_states_[session()->InitialConnection()]->num_sent_client_hellos();
 }
 
 int QuicCryptoClientStream::num_scup_messages_received() const {
-  return num_scup_messages_received_;
-}
-
-// Used in Chromium, but not in the server.
-bool QuicCryptoClientStream::WasChannelIDSent() const {
-  return channel_id_sent_;
-}
-
-bool QuicCryptoClientStream::WasChannelIDSourceCallbackRun() const {
-  return channel_id_source_callback_run_;
+  return connection_states_[session()->InitialConnection()]->num_scup_messages_received();
 }
 
 void QuicCryptoClientStream::HandleServerConfigUpdateMessage(
+    QuicCryptoClientStreamConnectionState* cs,
     const CryptoHandshakeMessage& server_config_update) {
   DCHECK(server_config_update.tag() == kSCUP);
   string error_details;
   QuicCryptoClientConfig::CachedState* cached =
-      crypto_config_->LookupOrCreate(server_id_);
+      crypto_config_->LookupOrCreate(cs->server_id_);
   QuicErrorCode error = crypto_config_->ProcessServerConfigUpdate(
-      server_config_update, connection()->clock()->WallNow(),
-      connection()->version(), chlo_hash_, cached,
-      crypto_negotiated_params_, &error_details);
+      server_config_update, cs->Connection()->clock()->WallNow(),
+      cs->Connection()->version(), chlo_hash_, cached,
+      cs->crypto_negotiated_params_, &error_details);
 
   if (error != QUIC_NO_ERROR) {
     CloseConnectionWithDetails(
@@ -183,48 +221,50 @@ void QuicCryptoClientStream::HandleServerConfigUpdateMessage(
     return;
   }
 
-  DCHECK(handshake_confirmed());
-  if (proof_verify_callback_) {
-    proof_verify_callback_->Cancel();
+  DCHECK(cs->handshake_confirmed());
+  if (cs->proof_verify_callback_) {
+    cs->proof_verify_callback_->Cancel();
   }
-  next_state_ = STATE_INITIALIZE_SCUP;
-  DoHandshakeLoop(nullptr);
+  cs->next_state_ = STATE_INITIALIZE_SCUP;
+  DoHandshakeLoop(cs, nullptr);
 }
 
-void QuicCryptoClientStream::DoHandshakeLoop(const CryptoHandshakeMessage* in) {
+void QuicCryptoClientStream::DoHandshakeLoop(
+    QuicCryptoClientStreamConnectionState* cs,
+    const CryptoHandshakeMessage* in) {
   QuicCryptoClientConfig::CachedState* cached =
-      crypto_config_->LookupOrCreate(server_id_);
+      crypto_config_->LookupOrCreate(cs->server_id_);
 
   QuicAsyncStatus rv = QUIC_SUCCESS;
   do {
-    CHECK_NE(STATE_NONE, next_state_);
-    const State state = next_state_;
-    next_state_ = STATE_IDLE;
+    CHECK_NE(STATE_NONE, cs->next_state_);
+    const State state = cs->next_state_;
+    cs->next_state_ = STATE_IDLE;
     rv = QUIC_SUCCESS;
     switch (state) {
       case STATE_INITIALIZE:
-        DoInitialize(cached);
+        DoInitialize(cs, cached);
         break;
       case STATE_SEND_CHLO:
-        DoSendCHLO(cached);
+        DoSendCHLO(cs, cached);
         return;  // return waiting to hear from server.
       case STATE_RECV_REJ:
-        DoReceiveREJ(in, cached);
+        DoReceiveREJ(cs, in, cached);
         break;
       case STATE_VERIFY_PROOF:
-        rv = DoVerifyProof(cached);
+        rv = DoVerifyProof(cs, cached);
         break;
       case STATE_VERIFY_PROOF_COMPLETE:
-        DoVerifyProofComplete(cached);
+        DoVerifyProofComplete(cs, cached);
         break;
       case STATE_GET_CHANNEL_ID:
-        rv = DoGetChannelID(cached);
+        rv = DoGetChannelID(cs, cached);
         break;
       case STATE_GET_CHANNEL_ID_COMPLETE:
-        DoGetChannelIDComplete();
+        DoGetChannelIDComplete(cs);
         break;
       case STATE_RECV_SHLO:
-        DoReceiveSHLO(in, cached);
+        DoReceiveSHLO(cs, in, cached);
         break;
       case STATE_IDLE:
         // This means that the peer sent us a message that we weren't expecting.
@@ -232,16 +272,17 @@ void QuicCryptoClientStream::DoHandshakeLoop(const CryptoHandshakeMessage* in) {
                                    "Handshake in idle state");
         return;
       case STATE_INITIALIZE_SCUP:
-        DoInitializeServerConfigUpdate(cached);
+        DoInitializeServerConfigUpdate(cs, cached);
         break;
       case STATE_NONE:
         QUIC_NOTREACHED();
         return;  // We are done.
     }
-  } while (rv != QUIC_PENDING && next_state_ != STATE_NONE);
+  } while (rv != QUIC_PENDING && cs->next_state_ != STATE_NONE);
 }
 
 void QuicCryptoClientStream::DoInitialize(
+    QuicCryptoClientStreamConnectionState* cs,
     QuicCryptoClientConfig::CachedState* cached) {
   if (!cached->IsEmpty() && !cached->signature().empty()) {
     // Note that we verify the proof even if the cached proof is valid.
@@ -250,23 +291,24 @@ void QuicCryptoClientStream::DoInitialize(
     // the proof.
     DCHECK(crypto_config_->proof_verifier());
     // Track proof verification time when cached server config is used.
-    proof_verify_start_time_ = base::TimeTicks::Now();
+    cs->proof_verify_start_time_ = base::TimeTicks::Now();
     chlo_hash_ = cached->chlo_hash();
     // If the cached state needs to be verified, do it now.
-    next_state_ = STATE_VERIFY_PROOF;
+    cs->next_state_ = STATE_VERIFY_PROOF;
   } else {
-    next_state_ = STATE_GET_CHANNEL_ID;
+    cs->next_state_ = STATE_GET_CHANNEL_ID;
   }
 }
 
 void QuicCryptoClientStream::DoSendCHLO(
+    QuicCryptoClientStreamConnectionState* cs,
     QuicCryptoClientConfig::CachedState* cached) {
-  if (stateless_reject_received_) {
+  if (cs->stateless_reject_received_) {
     // If we've gotten to this point, we've sent at least one hello
     // and received a stateless reject in response.  We cannot
     // continue to send hellos because the server has abandoned state
     // for this connection.  Abandon further handshakes.
-    next_state_ = STATE_NONE;
+    cs->next_state_ = STATE_NONE;
     if (session()->connected()) {
       session()->CloseConnection(
           QUIC_CRYPTO_HANDSHAKE_STATELESS_REJECT, "stateless reject received",
@@ -276,36 +318,38 @@ void QuicCryptoClientStream::DoSendCHLO(
   }
 
   // Send the client hello in plaintext.
-  connection()->SetDefaultEncryptionLevel(ENCRYPTION_NONE);
-  encryption_established_ = false;
-  if (num_client_hellos_ > kMaxClientHellos) {
+  cs->Connection()->SetDefaultEncryptionLevel(ENCRYPTION_NONE);
+  cs->encryption_established_ = false;
+  if (cs->num_client_hellos_ > kMaxClientHellos) {
+    //TODO(cyrill) Close connection, or just close subflow?
     CloseConnectionWithDetails(
         QUIC_CRYPTO_TOO_MANY_REJECTS,
         QuicStrCat("More than ", kMaxClientHellos, " rejects"));
     return;
   }
-  num_client_hellos_++;
+  cs->num_client_hellos_++;
 
   CryptoHandshakeMessage out;
   DCHECK(session() != nullptr);
   DCHECK(session()->config() != nullptr);
+  out.SetConnection(cs->Connection());
   // Send all the options, regardless of whether we're sending an
   // inchoate or subsequent hello.
   session()->config()->ToHandshakeMessage(&out);
 
   // Send a local timestamp to the server.
   out.SetValue(kCTIM,
-               connection()->clock()->WallNow().ToUNIXSeconds());
+               cs->Connection()->clock()->WallNow().ToUNIXSeconds());
 
-  if (!cached->IsComplete(connection()->clock()->WallNow())) {
+  if (!cached->IsComplete(cs->Connection()->clock()->WallNow())) {
     crypto_config_->FillInchoateClientHello(
-        server_id_, connection()->supported_versions().front(),
-        cached, connection()->random_generator(),
-        /* demand_x509_proof= */ true, crypto_negotiated_params_, &out);
+        cs->server_id_, cs->Connection()->supported_versions().front(),
+        cached, cs->Connection()->random_generator(),
+        /* demand_x509_proof= */ true, cs->crypto_negotiated_params_, &out);
     // Pad the inchoate client hello to fill up a packet.
     const QuicByteCount kFramingOverhead = 50;  // A rough estimate.
     const QuicByteCount max_packet_size =
-        connection()->max_packet_length();
+        cs->Connection()->max_packet_length();
     if (max_packet_size <= kFramingOverhead) {
       QUIC_DLOG(DFATAL) << "max_packet_length (" << max_packet_size
                         << ") has no room for framing overhead.";
@@ -322,7 +366,7 @@ void QuicCryptoClientStream::DoSendCHLO(
     // FLAGS_quic_reloadable_flag_quic_use_chlo_packet_size
     out.set_minimum_size(
         static_cast<size_t>(max_packet_size - kFramingOverhead));
-    next_state_ = STATE_RECV_REJ;
+    cs->next_state_ = STATE_RECV_REJ;
     CryptoUtils::HashHandshakeMessage(out, &chlo_hash_, Perspective::IS_CLIENT);
     SendHandshakeMessage(out);
     return;
@@ -331,19 +375,19 @@ void QuicCryptoClientStream::DoSendCHLO(
   // If the server nonce is empty, copy over the server nonce from a previous
   // SREJ, if there is one.
   if (FLAGS_quic_reloadable_flag_enable_quic_stateless_reject_support &&
-      crypto_negotiated_params_->server_nonce.empty() &&
+      cs->crypto_negotiated_params_->server_nonce.empty() &&
       cached->has_server_nonce()) {
-    crypto_negotiated_params_->server_nonce = cached->GetNextServerNonce();
-    DCHECK(!crypto_negotiated_params_->server_nonce.empty());
+    cs->crypto_negotiated_params_->server_nonce = cached->GetNextServerNonce();
+    DCHECK(!cs->crypto_negotiated_params_->server_nonce.empty());
   }
 
   string error_details;
   QuicErrorCode error = crypto_config_->FillClientHello(
-      server_id_, connection()->connection_id(),
-      connection()->supported_versions().front(), cached,
-      connection()->clock()->WallNow(),
-      connection()->random_generator(), channel_id_key_.get(),
-      crypto_negotiated_params_, &out, &error_details);
+      cs->server_id_, cs->Connection()->connection_id(),
+      cs->Connection()->supported_versions().front(), cached,
+      cs->Connection()->clock()->WallNow(),
+      cs->Connection()->random_generator(), cs->channel_id_key_.get(),
+      cs->crypto_negotiated_params_, &out, &error_details);
   if (error != QUIC_NO_ERROR) {
     // Flush the cached config so that, if it's bad, the server has a
     // chance to send us another in the future.
@@ -352,32 +396,33 @@ void QuicCryptoClientStream::DoSendCHLO(
     return;
   }
   CryptoUtils::HashHandshakeMessage(out, &chlo_hash_, Perspective::IS_CLIENT);
-  channel_id_sent_ = (channel_id_key_.get() != nullptr);
+  cs->channel_id_sent_ = (cs->channel_id_key_.get() != nullptr);
   if (cached->proof_verify_details()) {
-    proof_handler_->OnProofVerifyDetailsAvailable(
+    cs->proof_handler_->OnProofVerifyDetailsAvailable(
         *cached->proof_verify_details());
   }
-  next_state_ = STATE_RECV_SHLO;
+  cs->next_state_ = STATE_RECV_SHLO;
   SendHandshakeMessage(out);
   // Be prepared to decrypt with the new server write key.
-  connection()->SetAlternativeDecrypter(
+  cs->Connection()->SetAlternativeDecrypter(
       ENCRYPTION_INITIAL,
-      crypto_negotiated_params_->initial_crypters.decrypter.release(),
+      cs->crypto_negotiated_params_->initial_crypters.decrypter.release(),
       true /* latch once used */);
   // Send subsequent packets under encryption on the assumption that the
   // server will accept the handshake.
-  connection()->SetEncrypter(
+  cs->Connection()->SetEncrypter(
       ENCRYPTION_INITIAL,
-      crypto_negotiated_params_->initial_crypters.encrypter.release());
-  connection()->SetDefaultEncryptionLevel(ENCRYPTION_INITIAL);
+      cs->crypto_negotiated_params_->initial_crypters.encrypter.release());
+  cs->Connection()->SetDefaultEncryptionLevel(ENCRYPTION_INITIAL);
 
   // TODO(ianswett): Merge ENCRYPTION_REESTABLISHED and
   // ENCRYPTION_FIRST_ESTABLSIHED
-  encryption_established_ = true;
-  session()->OnCryptoHandshakeEvent(connection(), QuicSession::ENCRYPTION_REESTABLISHED);
+  cs->encryption_established_ = true;
+  session()->OnCryptoHandshakeEvent(cs->Connection(), QuicSession::ENCRYPTION_REESTABLISHED);
 }
 
 void QuicCryptoClientStream::DoReceiveREJ(
+    QuicCryptoClientStreamConnectionState* cs,
     const CryptoHandshakeMessage* in,
     QuicCryptoClientConfig::CachedState* cached) {
   // We sent a dummy CHLO because we didn't have enough information to
@@ -385,7 +430,7 @@ void QuicCryptoClientStream::DoReceiveREJ(
   // rejected. Here we hope to have a REJ that contains the information
   // that we need.
   if ((in->tag() != kREJ) && (in->tag() != kSREJ)) {
-    next_state_ = STATE_NONE;
+    cs->next_state_ = STATE_NONE;
     CloseConnectionWithDetails(QUIC_INVALID_CRYPTO_MESSAGE_TYPE,
                                "Expected REJ");
     return;
@@ -407,7 +452,7 @@ void QuicCryptoClientStream::DoReceiveREJ(
       packed_error |= 1 << (reason - 1);
     }
     DVLOG(1) << "Reasons for rejection: " << packed_error;
-    if (num_client_hellos_ == kMaxClientHellos) {
+    if (cs->num_client_hellos_ == kMaxClientHellos) {
       UMA_HISTOGRAM_SPARSE_SLOWLY("Net.QuicClientHelloRejectReasons.TooMany",
                                   packed_error);
     }
@@ -417,17 +462,17 @@ void QuicCryptoClientStream::DoReceiveREJ(
 
   // Receipt of a REJ message means that the server received the CHLO
   // so we can cancel and retransmissions.
-  connection()->NeuterUnencryptedPackets();
+  cs->Connection()->NeuterUnencryptedPackets();
 
-  stateless_reject_received_ = in->tag() == kSREJ;
+  cs->stateless_reject_received_ = in->tag() == kSREJ;
   string error_details;
   QuicErrorCode error = crypto_config_->ProcessRejection(
-      *in, connection()->clock()->WallNow(),
-      connection()->version(), chlo_hash_, cached,
-      crypto_negotiated_params_, &error_details);
+      *in, cs->Connection()->clock()->WallNow(),
+      cs->Connection()->version(), chlo_hash_, cached,
+      cs->crypto_negotiated_params_, &error_details);
 
   if (error != QUIC_NO_ERROR) {
-    next_state_ = STATE_NONE;
+    cs->next_state_ = STATE_NONE;
     CloseConnectionWithDetails(error, error_details);
     return;
   }
@@ -438,106 +483,109 @@ void QuicCryptoClientStream::DoReceiveREJ(
       // just added the server config to the cache and verified the proof,
       // so we can assume no CA trust changes or certificate expiration
       // has happened since then.
-      next_state_ = STATE_VERIFY_PROOF;
+      cs->next_state_ = STATE_VERIFY_PROOF;
       return;
     }
   }
-  next_state_ = STATE_GET_CHANNEL_ID;
+  cs->next_state_ = STATE_GET_CHANNEL_ID;
 }
 
 QuicAsyncStatus QuicCryptoClientStream::DoVerifyProof(
+    QuicCryptoClientStreamConnectionState* cs,
     QuicCryptoClientConfig::CachedState* cached) {
   ProofVerifier* verifier = crypto_config_->proof_verifier();
   DCHECK(verifier);
-  next_state_ = STATE_VERIFY_PROOF_COMPLETE;
-  generation_counter_ = cached->generation_counter();
+  cs->next_state_ = STATE_VERIFY_PROOF_COMPLETE;
+  cs->generation_counter_ = cached->generation_counter();
 
-  ProofVerifierCallbackImpl* proof_verify_callback =
-      new ProofVerifierCallbackImpl(this);
+  QuicCryptoClientStreamConnectionState::ProofVerifierCallbackImpl* proof_verify_callback =
+      new QuicCryptoClientStreamConnectionState::ProofVerifierCallbackImpl(cs);
 
-  verify_ok_ = false;
+  cs->verify_ok_ = false;
 
   QuicAsyncStatus status = verifier->VerifyProof(
-      server_id_.host(), server_id_.port(), cached->server_config(),
-      connection()->version(), chlo_hash_, cached->certs(),
-      cached->cert_sct(), cached->signature(), verify_context_.get(),
-      &verify_error_details_, &verify_details_,
+      cs->server_id_.host(), cs->server_id_.port(), cached->server_config(),
+      cs->Connection()->version(), chlo_hash_, cached->certs(),
+      cached->cert_sct(), cached->signature(), cs->verify_context_.get(),
+      &cs->verify_error_details_, &cs->verify_details_,
       std::unique_ptr<ProofVerifierCallback>(proof_verify_callback));
 
   switch (status) {
     case QUIC_PENDING:
-      proof_verify_callback_ = proof_verify_callback;
+      cs->proof_verify_callback_ = proof_verify_callback;
       QUIC_DVLOG(1) << "Doing VerifyProof";
       break;
     case QUIC_FAILURE:
       break;
     case QUIC_SUCCESS:
-      verify_ok_ = true;
+      cs->verify_ok_ = true;
       break;
   }
   return status;
 }
 
 void QuicCryptoClientStream::DoVerifyProofComplete(
+    QuicCryptoClientStreamConnectionState* cs,
     QuicCryptoClientConfig::CachedState* cached) {
-  if (!proof_verify_start_time_.is_null()) {
+  if (!cs->proof_verify_start_time_.is_null()) {
     UMA_HISTOGRAM_TIMES("Net.QuicSession.VerifyProofTime.CachedServerConfig",
-                        base::TimeTicks::Now() - proof_verify_start_time_);
+                        base::TimeTicks::Now() - cs->proof_verify_start_time_);
   }
-  if (!verify_ok_) {
-    if (verify_details_.get()) {
-      proof_handler_->OnProofVerifyDetailsAvailable(*verify_details_);
+  if (!cs->verify_ok_) {
+    if (cs->verify_details_.get()) {
+      cs->proof_handler_->OnProofVerifyDetailsAvailable(*cs->verify_details_);
     }
-    if (num_client_hellos_ == 0) {
+    if (cs->num_client_hellos_ == 0) {
       cached->Clear();
-      next_state_ = STATE_INITIALIZE;
+      cs->next_state_ = STATE_INITIALIZE;
       return;
     }
-    next_state_ = STATE_NONE;
+    cs->next_state_ = STATE_NONE;
     UMA_HISTOGRAM_BOOLEAN("Net.QuicVerifyProofFailed.HandshakeConfirmed",
-                          handshake_confirmed());
+                          cs->handshake_confirmed());
     CloseConnectionWithDetails(QUIC_PROOF_INVALID,
-                               "Proof invalid: " + verify_error_details_);
+                               "Proof invalid: " + cs->verify_error_details_);
     return;
   }
 
   // Check if generation_counter has changed between STATE_VERIFY_PROOF and
   // STATE_VERIFY_PROOF_COMPLETE state changes.
-  if (generation_counter_ != cached->generation_counter()) {
-    next_state_ = STATE_VERIFY_PROOF;
+  if (cs->generation_counter_ != cached->generation_counter()) {
+    cs->next_state_ = STATE_VERIFY_PROOF;
   } else {
     SetCachedProofValid(cached);
-    cached->SetProofVerifyDetails(verify_details_.release());
-    if (!handshake_confirmed()) {
-      next_state_ = STATE_GET_CHANNEL_ID;
+    cached->SetProofVerifyDetails(cs->verify_details_.release());
+    if (!cs->handshake_confirmed()) {
+      cs->next_state_ = STATE_GET_CHANNEL_ID;
     } else {
       // TODO: Enable Expect-Staple. https://crbug.com/631101
-      next_state_ = STATE_NONE;
+      cs->next_state_ = STATE_NONE;
     }
   }
 }
 
 QuicAsyncStatus QuicCryptoClientStream::DoGetChannelID(
+    QuicCryptoClientStreamConnectionState* cs,
     QuicCryptoClientConfig::CachedState* cached) {
-  next_state_ = STATE_GET_CHANNEL_ID_COMPLETE;
-  channel_id_key_.reset();
+  cs->next_state_ = STATE_GET_CHANNEL_ID_COMPLETE;
+  cs->channel_id_key_.reset();
   if (!RequiresChannelID(cached)) {
-    next_state_ = STATE_SEND_CHLO;
+    cs->next_state_ = STATE_SEND_CHLO;
     return QUIC_SUCCESS;
   }
 
-  ChannelIDSourceCallbackImpl* channel_id_source_callback =
-      new ChannelIDSourceCallbackImpl(this);
+  QuicCryptoClientStreamConnectionState::ChannelIDSourceCallbackImpl* channel_id_source_callback =
+      new QuicCryptoClientStreamConnectionState::ChannelIDSourceCallbackImpl(cs);
   QuicAsyncStatus status = crypto_config_->channel_id_source()->GetChannelIDKey(
-      server_id_.host(), &channel_id_key_, channel_id_source_callback);
+      cs->server_id_.host(), &cs->channel_id_key_, channel_id_source_callback);
 
   switch (status) {
     case QUIC_PENDING:
-      channel_id_source_callback_ = channel_id_source_callback;
+      cs->channel_id_source_callback_ = channel_id_source_callback;
       QUIC_DVLOG(1) << "Looking up channel ID";
       break;
     case QUIC_FAILURE:
-      next_state_ = STATE_NONE;
+      cs->next_state_ = STATE_NONE;
       delete channel_id_source_callback;
       CloseConnectionWithDetails(QUIC_INVALID_CHANNEL_ID_SIGNATURE,
                                  "Channel ID lookup failed");
@@ -549,20 +597,22 @@ QuicAsyncStatus QuicCryptoClientStream::DoGetChannelID(
   return status;
 }
 
-void QuicCryptoClientStream::DoGetChannelIDComplete() {
-  if (!channel_id_key_.get()) {
-    next_state_ = STATE_NONE;
+void QuicCryptoClientStream::DoGetChannelIDComplete(
+    QuicCryptoClientStreamConnectionState* cs) {
+  if (!cs->channel_id_key_.get()) {
+    cs->next_state_ = STATE_NONE;
     CloseConnectionWithDetails(QUIC_INVALID_CHANNEL_ID_SIGNATURE,
                                "Channel ID lookup failed");
     return;
   }
-  next_state_ = STATE_SEND_CHLO;
+  cs->next_state_ = STATE_SEND_CHLO;
 }
 
 void QuicCryptoClientStream::DoReceiveSHLO(
+    QuicCryptoClientStreamConnectionState* cs,
     const CryptoHandshakeMessage* in,
     QuicCryptoClientConfig::CachedState* cached) {
-  next_state_ = STATE_NONE;
+  cs->next_state_ = STATE_NONE;
   // We sent a CHLO that we expected to be accepted and now we're
   // hoping for a SHLO from the server to confirm that.  First check
   // to see whether the response was a reject, and if so, move on to
@@ -571,13 +621,13 @@ void QuicCryptoClientStream::DoReceiveSHLO(
     // alternative_decrypter will be nullptr if the original alternative
     // decrypter latched and became the primary decrypter. That happens
     // if we received a message encrypted with the INITIAL key.
-    if (connection()->alternative_decrypter() == nullptr) {
+    if (cs->Connection()->alternative_decrypter() == nullptr) {
       // The rejection was sent encrypted!
       CloseConnectionWithDetails(QUIC_CRYPTO_ENCRYPTION_LEVEL_INCORRECT,
                                  "encrypted REJ message");
       return;
     }
-    next_state_ = STATE_RECV_REJ;
+    cs->next_state_ = STATE_RECV_REJ;
     return;
   }
 
@@ -590,7 +640,7 @@ void QuicCryptoClientStream::DoReceiveSHLO(
   // alternative_decrypter will be nullptr if the original alternative
   // decrypter latched and became the primary decrypter. That happens
   // if we received a message encrypted with the INITIAL key.
-  if (connection()->alternative_decrypter() != nullptr) {
+  if (cs->Connection()->alternative_decrypter() != nullptr) {
     // The server hello was sent without encryption.
     CloseConnectionWithDetails(QUIC_CRYPTO_ENCRYPTION_LEVEL_INCORRECT,
                                "unencrypted SHLO message");
@@ -599,10 +649,10 @@ void QuicCryptoClientStream::DoReceiveSHLO(
 
   string error_details;
   QuicErrorCode error = crypto_config_->ProcessServerHello(
-      *in, connection()->connection_id(),
-      connection()->version(),
-      connection()->server_supported_versions(), cached,
-      crypto_negotiated_params_, &error_details);
+      *in, cs->Connection()->connection_id(),
+      cs->Connection()->version(),
+      cs->Connection()->server_supported_versions(), cached,
+      cs->crypto_negotiated_params_, &error_details);
 
   if (error != QUIC_NO_ERROR) {
     CloseConnectionWithDetails(error, "Server hello invalid: " + error_details);
@@ -613,49 +663,52 @@ void QuicCryptoClientStream::DoReceiveSHLO(
     CloseConnectionWithDetails(error, "Server hello invalid: " + error_details);
     return;
   }
-  session()->OnConfigNegotiated(connection());
+  session()->OnConfigNegotiated(cs->Connection());
 
-  CrypterPair* crypters = &crypto_negotiated_params_->forward_secure_crypters;
+  CrypterPair* crypters = &cs->crypto_negotiated_params_->forward_secure_crypters;
   // TODO(agl): we don't currently latch this decrypter because the idea
   // has been floated that the server shouldn't send packets encrypted
   // with the FORWARD_SECURE key until it receives a FORWARD_SECURE
   // packet from the client.
-  connection()->SetAlternativeDecrypter(
+  cs->Connection()->SetAlternativeDecrypter(
       ENCRYPTION_FORWARD_SECURE, crypters->decrypter.release(),
       false /* don't latch */);
-  connection()->SetEncrypter(ENCRYPTION_FORWARD_SECURE,
+  cs->Connection()->SetEncrypter(ENCRYPTION_FORWARD_SECURE,
                                         crypters->encrypter.release());
-  connection()->SetDefaultEncryptionLevel(ENCRYPTION_FORWARD_SECURE);
+  cs->Connection()->SetDefaultEncryptionLevel(ENCRYPTION_FORWARD_SECURE);
 
-  handshake_confirmed_ = true;
-  session()->OnCryptoHandshakeEvent(connection(), QuicSession::HANDSHAKE_CONFIRMED);
-  connection()->OnHandshakeComplete();
+  cs->handshake_confirmed_ = true;
+  session()->OnCryptoHandshakeEvent(cs->Connection(), QuicSession::HANDSHAKE_CONFIRMED);
+  cs->Connection()->OnHandshakeComplete();
 }
 
 void QuicCryptoClientStream::DoInitializeServerConfigUpdate(
+    QuicCryptoClientStreamConnectionState* cs,
     QuicCryptoClientConfig::CachedState* cached) {
   bool update_ignored = false;
   if (!cached->IsEmpty() && !cached->signature().empty()) {
     // Note that we verify the proof even if the cached proof is valid.
     DCHECK(crypto_config_->proof_verifier());
-    next_state_ = STATE_VERIFY_PROOF;
+    cs->next_state_ = STATE_VERIFY_PROOF;
   } else {
     update_ignored = true;
-    next_state_ = STATE_NONE;
+    cs->next_state_ = STATE_NONE;
   }
   UMA_HISTOGRAM_COUNTS("Net.QuicNumServerConfig.UpdateMessagesIgnored",
                        update_ignored);
 }
 
 void QuicCryptoClientStream::SetCachedProofValid(
+    QuicCryptoClientStreamConnectionState* cs,
     QuicCryptoClientConfig::CachedState* cached) {
   cached->SetProofValid();
-  proof_handler_->OnProofValid(*cached);
+  cs->proof_handler_->OnProofValid(*cached);
 }
 
 bool QuicCryptoClientStream::RequiresChannelID(
+    QuicCryptoClientStreamConnectionState* cs,
     QuicCryptoClientConfig::CachedState* cached) {
-  if (server_id_.privacy_mode() == PRIVACY_MODE_ENABLED ||
+  if (cs->server_id_.privacy_mode() == PRIVACY_MODE_ENABLED ||
       !crypto_config_->channel_id_source()) {
     return false;
   }

--- a/src/net/quic/core/quic_crypto_client_stream.h
+++ b/src/net/quic/core/quic_crypto_client_stream.h
@@ -30,10 +30,6 @@ class QUIC_EXPORT_PRIVATE QuicCryptoClientStreamBase : public QuicCryptoStream {
 
   ~QuicCryptoClientStreamBase() override{};
 
-  // Performs a crypto handshake with the server. Returns true if the connection
-  // is still connected.
-  virtual bool CryptoConnect() = 0;
-
   // num_sent_client_hellos returns the number of client hello messages that
   // have been sent. If the handshake has completed then this is one greater
   // than the number of round-trips needed for the handshake.
@@ -83,8 +79,10 @@ class QUIC_EXPORT_PRIVATE QuicCryptoClientStream
 
   ~QuicCryptoClientStream() override;
 
+  // from QuicCryptoStream
+  bool CryptoConnect(QuicConnection* connection) override;
+
   // From QuicCryptoClientStreamBase
-  bool CryptoConnect() override;
   int num_sent_client_hellos() const override;
 
   int num_scup_messages_received() const override;
@@ -92,55 +90,20 @@ class QUIC_EXPORT_PRIVATE QuicCryptoClientStream
   // CryptoFramerVisitorInterface implementation
   void OnHandshakeMessage(const CryptoHandshakeMessage& message) override;
 
-  // Returns true if a channel ID was sent on this connection.
-  bool WasChannelIDSent() const;
-
-  // Returns true if our ChannelIDSourceCallback was run, which implies the
-  // ChannelIDSource operated asynchronously. Intended for testing.
-  bool WasChannelIDSourceCallbackRun() const;
-
   std::string chlo_hash() const { return chlo_hash_; }
 
  private:
-  // ChannelIDSourceCallbackImpl is passed as the callback method to
-  // GetChannelIDKey. The ChannelIDSource calls this class with the result of
-  // channel ID lookup when lookup is performed asynchronously.
-  class ChannelIDSourceCallbackImpl : public ChannelIDSourceCallback {
-   public:
-    explicit ChannelIDSourceCallbackImpl(QuicCryptoClientStream* stream);
-    ~ChannelIDSourceCallbackImpl() override;
 
-    // ChannelIDSourceCallback interface.
-    void Run(std::unique_ptr<ChannelIDKey>* channel_id_key) override;
+  // Adds a connection state for an additional subflow that uses
+  // the same proofer and server id privacy mode as an existing
+  // connection state.
+  void AddConnectionState(QuicConnection* connection);
 
-    // Cancel causes any future callbacks to be ignored. It must be called on
-    // the same thread as the callback will be made on.
-    void Cancel();
-
-   private:
-    QuicCryptoClientStream* stream_;
-  };
-
-  // ProofVerifierCallbackImpl is passed as the callback method to VerifyProof.
-  // The ProofVerifier calls this class with the result of proof verification
-  // when verification is performed asynchronously.
-  class ProofVerifierCallbackImpl : public ProofVerifierCallback {
-   public:
-    explicit ProofVerifierCallbackImpl(QuicCryptoClientStream* stream);
-    ~ProofVerifierCallbackImpl() override;
-
-    // ProofVerifierCallback interface.
-    void Run(bool ok,
-             const std::string& error_details,
-             std::unique_ptr<ProofVerifyDetails>* details) override;
-
-    // Cancel causes any future callbacks to be ignored. It must be called on
-    // the same thread as the callback will be made on.
-    void Cancel();
-
-   private:
-    QuicCryptoClientStream* stream_;
-  };
+  // Adds a connection state with a specific proofer and server id.
+  void AddConnectionState(QuicConnection* connection,
+                          ProofVerifyContext* verify_context,
+                          const QuicServerId& server_id,
+                          ProofHandler* proof_handler);
 
   friend class test::QuicChromiumClientSessionPeer;
 
@@ -158,118 +121,219 @@ class QUIC_EXPORT_PRIVATE QuicCryptoClientStream
     STATE_NONE,
   };
 
+  class QUIC_EXPORT_PRIVATE QuicCryptoClientStreamConnectionState : public QuicCryptoStreamConnectionState {
+  public:
+    QuicCryptoClientStreamConnectionState(
+                    QuicConnection* connection,
+                    ProofVerifyContext* verify_context,
+                    const QuicServerId& server_id,
+                    ProofHandler* proof_handler,
+                    QuicCryptoClientStream* stream);
+
+    ~QuicCryptoClientStreamConnectionState() override;
+
+    // ChannelIDSourceCallbackImpl is passed as the callback method to
+    // GetChannelIDKey. The ChannelIDSource calls this class with the result of
+    // channel ID lookup when lookup is performed asynchronously.
+    class ChannelIDSourceCallbackImpl : public ChannelIDSourceCallback {
+     public:
+      explicit ChannelIDSourceCallbackImpl(QuicCryptoClientStreamConnectionState* connection_state);
+      ~ChannelIDSourceCallbackImpl() override;
+
+      // ChannelIDSourceCallback interface.
+      void Run(std::unique_ptr<ChannelIDKey>* channel_id_key) override;
+
+      // Cancel causes any future callbacks to be ignored. It must be called on
+      // the same thread as the callback will be made on.
+      void Cancel();
+
+     private:
+      QuicCryptoClientStreamConnectionState* connection_state_;
+    };
+
+    // ProofVerifierCallbackImpl is passed as the callback method to VerifyProof.
+    // The ProofVerifier calls this class with the result of proof verification
+    // when verification is performed asynchronously.
+    class ProofVerifierCallbackImpl : public ProofVerifierCallback {
+     public:
+      explicit ProofVerifierCallbackImpl(QuicCryptoClientStreamConnectionState* connection_state);
+      ~ProofVerifierCallbackImpl() override;
+
+      // ProofVerifierCallback interface.
+      void Run(bool ok,
+               const std::string& error_details,
+               std::unique_ptr<ProofVerifyDetails>* details) override;
+
+      // Cancel causes any future callbacks to be ignored. It must be called on
+      // the same thread as the callback will be made on.
+      void Cancel();
+
+     private:
+      QuicCryptoClientStreamConnectionState* connection_state_;
+    };
+
+    void ProofVerifyComplete() {
+      stream_->DoHandshakeLoop(this, nullptr);
+    }
+
+    void GetChannelIdComplete() {
+      stream_->DoHandshakeLoop(this, nullptr);
+    }
+
+    int num_sent_client_hellos() const { return num_client_hellos_; }
+
+    int num_scup_messages_received() const { return num_scup_messages_received_; }
+
+    // Returns true if a channel ID was sent on this connection.
+    bool WasChannelIDSent() const { return channel_id_sent_; }
+
+    // Returns true if our ChannelIDSourceCallback was run, which implies the
+    // ChannelIDSource operated asynchronously. Intended for testing.
+    bool WasChannelIDSourceCallbackRun() const { return channel_id_source_callback_run_; }
+
+    State next_state_;
+    // num_client_hellos_ contains the number of client hello messages that this
+    // connection has sent.
+    int num_client_hellos_;
+
+    // SHA-256 hash of the most recently sent CHLO on this connection.
+    std::string chlo_hash_;
+
+    // Server's (hostname, port, is_https, privacy_mode) tuple.
+    const QuicServerId server_id_;
+
+    // Generation counter from QuicCryptoClientConfig's CachedState.
+    uint64_t generation_counter_;
+
+    // True if a channel ID was sent.
+    bool channel_id_sent_;
+
+    // True if channel_id_source_callback_ was run.
+    bool channel_id_source_callback_run_;
+
+    // channel_id_source_callback_ contains the callback object that we passed
+    // to an asynchronous channel ID lookup. The ChannelIDSource owns this
+    // object.
+    ChannelIDSourceCallbackImpl* channel_id_source_callback_;
+
+    // These members are used to store the result of an asynchronous channel ID
+    // lookup. These members must not be used after
+    // STATE_GET_CHANNEL_ID_COMPLETE.
+    std::unique_ptr<ChannelIDKey> channel_id_key_;
+
+    // verify_context_ contains the context object that we pass to asynchronous
+    // proof verifications.
+    std::unique_ptr<ProofVerifyContext> verify_context_;
+
+    // proof_verify_callback_ contains the callback object that we passed to an
+    // asynchronous proof verification. The ProofVerifier owns this object.
+    ProofVerifierCallbackImpl* proof_verify_callback_;
+    // proof_handler_ contains the callback object used by a quic client
+    // for proof verification. It is not owned by this class.
+    ProofHandler* proof_handler_;
+
+    // These members are used to store the result of an asynchronous proof
+    // verification. These members must not be used after
+    // STATE_VERIFY_PROOF_COMPLETE.
+    bool verify_ok_;
+    std::string verify_error_details_;
+    std::unique_ptr<ProofVerifyDetails> verify_details_;
+
+    // True if the server responded to a previous CHLO with a stateless
+    // reject.  Used for book-keeping between the STATE_RECV_REJ,
+    // STATE_VERIFY_PROOF*, and subsequent STATE_SEND_CHLO state.
+    bool stateless_reject_received_;
+
+    // Only used in chromium, not internally.
+    base::TimeTicks proof_verify_start_time_;
+
+    int num_scup_messages_received_;
+
+    QuicCryptoClientStream* stream_;
+  };
+
   // Handles new server config and optional source-address token provided by the
   // server during a connection.
   void HandleServerConfigUpdateMessage(
+      QuicCryptoClientStreamConnectionState* connection_state,
       const CryptoHandshakeMessage& server_config_update);
 
   // DoHandshakeLoop performs a step of the handshake state machine. Note that
   // |in| may be nullptr if the call did not result from a received message.
-  void DoHandshakeLoop(const CryptoHandshakeMessage* in);
+  void DoHandshakeLoop(
+      QuicCryptoClientStreamConnectionState* connection_state,
+      const CryptoHandshakeMessage* in);
 
   // Start the handshake process.
-  void DoInitialize(QuicCryptoClientConfig::CachedState* cached);
+  void DoInitialize(
+      QuicCryptoClientStreamConnectionState* connection_state,
+      QuicCryptoClientConfig::CachedState* cached);
 
   // Send either InchoateClientHello or ClientHello message to the server.
-  void DoSendCHLO(QuicCryptoClientConfig::CachedState* cached);
+  void DoSendCHLO(
+      QuicCryptoClientStreamConnectionState* connection_state,
+      QuicCryptoClientConfig::CachedState* cached);
 
   // Process REJ message from the server.
-  void DoReceiveREJ(const CryptoHandshakeMessage* in,
-                    QuicCryptoClientConfig::CachedState* cached);
+  void DoReceiveREJ(
+      QuicCryptoClientStreamConnectionState* connection_state,
+      const CryptoHandshakeMessage* in,
+      QuicCryptoClientConfig::CachedState* cached);
 
   // Start the proof verification process. Returns the QuicAsyncStatus returned
   // by the ProofVerifier's VerifyProof.
-  QuicAsyncStatus DoVerifyProof(QuicCryptoClientConfig::CachedState* cached);
+  QuicAsyncStatus DoVerifyProof(
+      QuicCryptoClientStreamConnectionState* connection_state,
+      QuicCryptoClientConfig::CachedState* cached);
 
   // If proof is valid then it sets the proof as valid (which persists the
   // server config). If not, it closes the connection.
-  void DoVerifyProofComplete(QuicCryptoClientConfig::CachedState* cached);
+  void DoVerifyProofComplete(
+      QuicCryptoClientStreamConnectionState* connection_state,
+      QuicCryptoClientConfig::CachedState* cached);
 
   // Start the look up of Channel ID process. Returns either QUIC_SUCCESS if
   // RequiresChannelID returns false or QuicAsyncStatus returned by
   // GetChannelIDKey.
-  QuicAsyncStatus DoGetChannelID(QuicCryptoClientConfig::CachedState* cached);
+  QuicAsyncStatus DoGetChannelID(
+      QuicCryptoClientStreamConnectionState* connection_state,
+      QuicCryptoClientConfig::CachedState* cached);
 
   // If there is no channel ID, then close the connection otherwise transtion to
   // STATE_SEND_CHLO state.
-  void DoGetChannelIDComplete();
+  void DoGetChannelIDComplete(
+      QuicCryptoClientStreamConnectionState* connection_state);
 
   // Process SHLO message from the server.
-  void DoReceiveSHLO(const CryptoHandshakeMessage* in,
-                     QuicCryptoClientConfig::CachedState* cached);
+  void DoReceiveSHLO(
+      QuicCryptoClientStreamConnectionState* connection_state,
+      const CryptoHandshakeMessage* in,
+      QuicCryptoClientConfig::CachedState* cached);
 
   // Start the proof verification if |server_id_| is https and |cached| has
   // signature.
   void DoInitializeServerConfigUpdate(
+      QuicCryptoClientStreamConnectionState* connection_state,
       QuicCryptoClientConfig::CachedState* cached);
 
   // Called to set the proof of |cached| valid.  Also invokes the session's
   // OnProofValid() method.
-  void SetCachedProofValid(QuicCryptoClientConfig::CachedState* cached);
+  void SetCachedProofValid(
+      QuicCryptoClientStreamConnectionState* connection_state,
+      QuicCryptoClientConfig::CachedState* cached);
 
   // Returns true if the server crypto config in |cached| requires a ChannelID
   // and the client config settings also allow sending a ChannelID.
-  bool RequiresChannelID(QuicCryptoClientConfig::CachedState* cached);
-
-  State next_state_;
-  // num_client_hellos_ contains the number of client hello messages that this
-  // connection has sent.
-  int num_client_hellos_;
+  bool RequiresChannelID(
+      QuicCryptoClientStreamConnectionState* connection_state,
+      QuicCryptoClientConfig::CachedState* cached);
 
   QuicCryptoClientConfig* const crypto_config_;
 
   // SHA-256 hash of the most recently sent CHLO.
   std::string chlo_hash_;
 
-  // Server's (hostname, port, is_https, privacy_mode) tuple.
-  const QuicServerId server_id_;
-
-  // Generation counter from QuicCryptoClientConfig's CachedState.
-  uint64_t generation_counter_;
-
-  // True if a channel ID was sent.
-  bool channel_id_sent_;
-
-  // True if channel_id_source_callback_ was run.
-  bool channel_id_source_callback_run_;
-
-  // channel_id_source_callback_ contains the callback object that we passed
-  // to an asynchronous channel ID lookup. The ChannelIDSource owns this
-  // object.
-  ChannelIDSourceCallbackImpl* channel_id_source_callback_;
-
-  // These members are used to store the result of an asynchronous channel ID
-  // lookup. These members must not be used after
-  // STATE_GET_CHANNEL_ID_COMPLETE.
-  std::unique_ptr<ChannelIDKey> channel_id_key_;
-
-  // verify_context_ contains the context object that we pass to asynchronous
-  // proof verifications.
-  std::unique_ptr<ProofVerifyContext> verify_context_;
-
-  // proof_verify_callback_ contains the callback object that we passed to an
-  // asynchronous proof verification. The ProofVerifier owns this object.
-  ProofVerifierCallbackImpl* proof_verify_callback_;
-  // proof_handler_ contains the callback object used by a quic client
-  // for proof verification. It is not owned by this class.
-  ProofHandler* proof_handler_;
-
-  // These members are used to store the result of an asynchronous proof
-  // verification. These members must not be used after
-  // STATE_VERIFY_PROOF_COMPLETE.
-  bool verify_ok_;
-  std::string verify_error_details_;
-  std::unique_ptr<ProofVerifyDetails> verify_details_;
-
-  // True if the server responded to a previous CHLO with a stateless
-  // reject.  Used for book-keeping between the STATE_RECV_REJ,
-  // STATE_VERIFY_PROOF*, and subsequent STATE_SEND_CHLO state.
-  bool stateless_reject_received_;
-
-  // Only used in chromium, not internally.
-  base::TimeTicks proof_verify_start_time_;
-
-  int num_scup_messages_received_;
+  //std::map<QuicConnection*, std::shared_ptr<QuicCryptoClientStreamConnectionState> > connection_states_;
 
   DISALLOW_COPY_AND_ASSIGN(QuicCryptoClientStream);
 };

--- a/src/net/quic/core/quic_crypto_client_stream.h
+++ b/src/net/quic/core/quic_crypto_client_stream.h
@@ -101,7 +101,7 @@ class QUIC_EXPORT_PRIVATE QuicCryptoClientStream
 
   // Adds a connection state with a specific proofer and server id.
   void AddConnectionState(QuicConnection* connection,
-                          ProofVerifyContext* verify_context,
+                          std::shared_ptr<ProofVerifyContext> verify_context,
                           const QuicServerId& server_id,
                           ProofHandler* proof_handler);
 
@@ -125,7 +125,7 @@ class QUIC_EXPORT_PRIVATE QuicCryptoClientStream
   public:
     QuicCryptoClientStreamConnectionState(
                     QuicConnection* connection,
-                    ProofVerifyContext* verify_context,
+                    std::shared_ptr<ProofVerifyContext> verify_context,
                     const QuicServerId& server_id,
                     ProofHandler* proof_handler,
                     QuicCryptoClientStream* stream);
@@ -223,7 +223,7 @@ class QUIC_EXPORT_PRIVATE QuicCryptoClientStream
 
     // verify_context_ contains the context object that we pass to asynchronous
     // proof verifications.
-    std::unique_ptr<ProofVerifyContext> verify_context_;
+    std::shared_ptr<ProofVerifyContext> verify_context_;
 
     // proof_verify_callback_ contains the callback object that we passed to an
     // asynchronous proof verification. The ProofVerifier owns this object.
@@ -251,6 +251,9 @@ class QUIC_EXPORT_PRIVATE QuicCryptoClientStream
 
     QuicCryptoClientStream* stream_;
   };
+
+  QuicCryptoClientStreamConnectionState*
+      GetClientConnectionState(const QuicConnection* connection) const;
 
   // Handles new server config and optional source-address token provided by the
   // server during a connection.

--- a/src/net/quic/core/quic_crypto_server_stream.h
+++ b/src/net/quic/core/quic_crypto_server_stream.h
@@ -135,6 +135,7 @@ class QUIC_EXPORT_PRIVATE QuicCryptoServerStream
   class QuicCryptoServerStreamConnectionState;
 
   virtual void ProcessClientHello(
+      QuicCryptoServerStreamConnectionState* cs,
       QuicReferenceCountedPointer<ValidateClientHelloResultCallback::Result>
           result,
       std::unique_ptr<ProofSource::Details> proof_source_details,
@@ -284,6 +285,9 @@ class QUIC_EXPORT_PRIVATE QuicCryptoServerStream
     void FinishSendServerConfigUpdate(bool ok,
                                       const CryptoHandshakeMessage& message);
   };
+
+  QuicCryptoServerStreamConnectionState*
+  GetServerConnectionState(const QuicConnection* connection) const;
 
  private:
   friend class test::QuicCryptoServerStreamPeer;

--- a/src/net/quic/core/quic_crypto_stream.cc
+++ b/src/net/quic/core/quic_crypto_stream.cc
@@ -11,6 +11,7 @@
 #include "net/quic/core/quic_connection.h"
 #include "net/quic/core/quic_session.h"
 #include "net/quic/core/quic_utils.h"
+#include "net/quic/core/quic_stream_sequencer_buffer.h"
 #include "net/quic/platform/api/quic_flag_utils.h"
 #include "net/quic/platform/api/quic_flags.h"
 #include "net/quic/platform/api/quic_logging.h"
@@ -27,17 +28,18 @@ QuicCryptoStream::QuicCryptoStream(QuicSession* session)
     : QuicCryptoStream(session,session->InitialConnection()) {}
 
 QuicCryptoStream::QuicCryptoStream(QuicSession* session, QuicConnection* connection)
-    : QuicStream(kCryptoStreamId, session),
-      encryption_established_(false),
-      handshake_confirmed_(false),
-      crypto_negotiated_params_(new QuicCryptoNegotiatedParameters),
-      connection_(connection) {
+    : QuicStream(kCryptoStreamId, session) {
   crypto_framer_.set_visitor(this);
   // The crypto stream is exempt from connection level flow control.
   DisableConnectionFlowControlForThisStream();
 }
 
 QuicCryptoStream::~QuicCryptoStream() {}
+
+bool QuicCryptoStream::CryptoConnect(QuicConnection* connection) {
+  QUIC_BUG << "QuicCryptoStream::CryptoConnect is not overwritten in subclass";
+  return false;
+}
 
 // static
 QuicByteCount QuicCryptoStream::CryptoMessageFramingOverhead(
@@ -63,19 +65,23 @@ void QuicCryptoStream::OnHandshakeMessage(
 
 void QuicCryptoStream::OnDataAvailable() {
   struct iovec iov;
+  struct FrameInfo fi;
   while (true) {
-    if (sequencer()->GetReadableRegions(&iov, 1) != 1) {
+    if (sequencer()->GetReadableRegion(&iov, &fi) != 1) {
       // No more data to read.
       break;
     }
+    QuicConnection *connection = fi.connection;
     QuicStringPiece data(static_cast<char*>(iov.iov_base), iov.iov_len);
+    crypto_framer_.set_process_connection(connection);
     if (!crypto_framer_.ProcessInput(data, session()->perspective())) {
       CloseConnectionWithDetails(crypto_framer_.error(),
                                  crypto_framer_.error_detail());
       return;
     }
     sequencer()->MarkConsumed(iov.iov_len);
-    if (handshake_confirmed_ && crypto_framer_.InputBytesRemaining() == 0 &&
+    if (GetConnectionState(connection)->handshake_confirmed_ &&
+        crypto_framer_.InputBytesRemaining() == 0 &&
         FLAGS_quic_reloadable_flag_quic_release_crypto_stream_buffer) {
       QUIC_FLAG_COUNT(quic_reloadable_flag_quic_release_crypto_stream_buffer);
       // If the handshake is complete and the current message has been fully
@@ -90,42 +96,52 @@ void QuicCryptoStream::SendHandshakeMessage(
     const CryptoHandshakeMessage& message) {
   QUIC_DVLOG(1) << ENDPOINT << "Sending "
                 << message.DebugString(session()->perspective());
-  connection()->NeuterUnencryptedPackets();
+  message.Connection()->NeuterUnencryptedPackets();
   session()->OnCryptoHandshakeMessageSent(message);
   const QuicData& data = message.GetSerialized(session()->perspective());
   WriteOrBufferData(QuicStringPiece(data.data(), data.length()), false,
-                    nullptr);
+                    nullptr, message.Connection());
 }
 
 bool QuicCryptoStream::ExportKeyingMaterial(QuicStringPiece label,
                                             QuicStringPiece context,
                                             size_t result_len,
                                             string* result) const {
-  if (!handshake_confirmed()) {
+  if (!GetInitialConnectionState()->handshake_confirmed()) {
     QUIC_DLOG(ERROR) << "ExportKeyingMaterial was called before forward-secure"
                      << "encryption was established.";
     return false;
   }
   return CryptoUtils::ExportKeyingMaterial(
-      crypto_negotiated_params_->subkey_secret, label, context, result_len,
+      GetInitialConnectionState()->crypto_negotiated_params_->subkey_secret, label, context, result_len,
       result);
 }
 
 bool QuicCryptoStream::ExportTokenBindingKeyingMaterial(string* result) const {
-  if (!encryption_established()) {
+  if (!GetInitialConnectionState()->encryption_established()) {
     QUIC_BUG << "ExportTokenBindingKeyingMaterial was called before initial"
              << "encryption was established.";
     return false;
   }
   return CryptoUtils::ExportKeyingMaterial(
-      crypto_negotiated_params_->initial_subkey_secret,
+      GetInitialConnectionState()->crypto_negotiated_params_->initial_subkey_secret,
       "EXPORTER-Token-Binding",
       /* context= */ "", 32, result);
 }
 
 const QuicCryptoNegotiatedParameters&
 QuicCryptoStream::crypto_negotiated_params() const {
-  return *crypto_negotiated_params_;
+  return *GetInitialConnectionState()->crypto_negotiated_params_;
 }
+
+QuicCryptoStream::QuicCryptoStreamConnectionState::
+QuicCryptoStreamConnectionState(QuicConnection* connection) :
+  encryption_established_(false),
+  handshake_confirmed_(false),
+  crypto_negotiated_params_(new QuicCryptoNegotiatedParameters),
+  connection_(connection) {}
+
+QuicCryptoStream::QuicCryptoStreamConnectionState::
+~QuicCryptoStreamConnectionState() {}
 
 }  // namespace net

--- a/src/net/quic/core/quic_crypto_stream.h
+++ b/src/net/quic/core/quic_crypto_stream.h
@@ -16,6 +16,7 @@
 #include "net/quic/platform/api/quic_export.h"
 #include "net/quic/platform/api/quic_string_piece.h"
 
+
 namespace net {
 
 class CryptoHandshakeMessage;
@@ -39,6 +40,10 @@ class QUIC_EXPORT_PRIVATE QuicCryptoStream
       explicit QuicCryptoStream(QuicSession* session, QuicConnection* connection);
 
   ~QuicCryptoStream() override;
+
+  // Initiate sending handshake messages to establish a secure connection.
+  // Returns true if the session is still connected.
+  virtual bool CryptoConnect(QuicConnection* connection);
 
   // Returns the per-packet framing overhead associated with sending a
   // handshake message for |version|.
@@ -74,26 +79,59 @@ class QUIC_EXPORT_PRIVATE QuicCryptoStream
   // value.
   bool ExportTokenBindingKeyingMaterial(std::string* result) const;
 
-  bool encryption_established() const { return encryption_established_; }
-  bool handshake_confirmed() const { return handshake_confirmed_; }
-
   const QuicCryptoNegotiatedParameters& crypto_negotiated_params() const;
 
  protected:
-  bool encryption_established_;
-  bool handshake_confirmed_;
+  class QUIC_EXPORT_PRIVATE QuicCryptoStreamConnectionState {
+  public:
+    QuicCryptoStreamConnectionState(QuicConnection* connection);
+    virtual ~QuicCryptoStreamConnectionState();
 
-  QuicReferenceCountedPointer<QuicCryptoNegotiatedParameters>
-      crypto_negotiated_params_;
+    bool encryption_established() const { return encryption_established_; }
+    bool handshake_confirmed() const { return handshake_confirmed_; }
+    QuicConnection* Connection() { return connection_; }
 
-  QuicConnection* connection() { return connection_; }
+    bool encryption_established_;
+    bool handshake_confirmed_;
+
+    QuicReferenceCountedPointer<QuicCryptoNegotiatedParameters>
+        crypto_negotiated_params_;
+
+  private:
+    QuicConnection* connection_;
+  };
+
+  void AddConnectionState(QuicConnection* connection,
+      QuicCryptoStreamConnectionState* connection_state) {
+    connection_states_.insert(
+        std::pair<QuicConnection*, std::unique_ptr<QuicCryptoStreamConnectionState> >(
+            connection,
+            std::unique_ptr<QuicCryptoStreamConnectionState>(connection_state)));
+  }
+
+  //QuicConnection* connection() { return connection_; }
+
+  QuicCryptoStreamConnectionState* GetConnectionState(QuicConnection* connection) {
+    auto it = connection_states_.find(connection);
+    if(it == connection_states_.end()) {
+      return nullptr;
+    } else {
+      return it->second.get();
+    }
+  }
+
+  // Get the connection state of the initial connection/subflow.
+  // This is only used for functions that do not use multipathing
+  // and cannot be removed from the build due to dependencies.
+  QuicCryptoStreamConnectionState* GetInitialConnectionState() const {
+    DCHECK(false);
+    return nullptr;//connection_states_[session()->InitialConnection()];
+  }
+
+  std::map<QuicConnection*, std::unique_ptr<QuicCryptoStreamConnectionState> > connection_states_;
 
  private:
   CryptoFramer crypto_framer_;
-
-  // The connection on which the crypto handshake should be performed.
-  // (not owned)
-  QuicConnection* connection_;
 
   DISALLOW_COPY_AND_ASSIGN(QuicCryptoStream);
 };

--- a/src/net/quic/core/quic_server_session_base.cc
+++ b/src/net/quic/core/quic_server_session_base.cc
@@ -184,7 +184,7 @@ void QuicServerSessionBase::OnCongestionWindowChange(QuicConnection* connection,
     cached_network_params.set_serving_region(serving_region_);
   }
 
-  crypto_stream_->SendServerConfigUpdate(&cached_network_params);
+  crypto_stream_->SendServerConfigUpdate(connection, &cached_network_params);
 
   connection->OnSendConnectionState(cached_network_params);
 
@@ -216,7 +216,7 @@ bool QuicServerSessionBase::ShouldCreateOutgoingDynamicStream() {
     QUIC_BUG << "ShouldCreateOutgoingDynamicStream called when disconnected";
     return false;
   }
-  if (!crypto_stream_->encryption_established()) {
+  if (!crypto_stream_->encryption_established(nullptr)) {
     QUIC_BUG << "Encryption not established so no outgoing stream created.";
     return false;
   }

--- a/src/net/quic/core/quic_server_session_base.cc
+++ b/src/net/quic/core/quic_server_session_base.cc
@@ -64,7 +64,7 @@ void QuicServerSessionBase::OnConfigNegotiated(QuicConnection *connection) {
   // region as this server, then decide whether to use the data for bandwidth
   // resumption.
   const CachedNetworkParameters* cached_network_params =
-      crypto_stream_->PreviousCachedNetworkParams();
+      crypto_stream_->PreviousCachedNetworkParams(connection);
   if (cached_network_params != nullptr &&
       cached_network_params->serving_region() == serving_region_) {
     // Log the received connection parameters, regardless of how they

--- a/src/net/quic/core/quic_session.cc
+++ b/src/net/quic/core/quic_session.cc
@@ -70,7 +70,7 @@ QuicSession::~QuicSession() {
       << GetNumLocallyClosedOutgoingStreamsHighestOffset();
 }
 
-void QuicSession::OnStreamFrame(const QuicStreamFrame& frame) {
+void QuicSession::OnStreamFrame(const QuicStreamFrame& frame, QuicConnection *connection) {
   // TODO(rch) deal with the error case of stream id 0.
   QuicStreamId stream_id = frame.stream_id;
   QuicStream* stream = GetOrCreateStream(stream_id);
@@ -84,7 +84,7 @@ void QuicSession::OnStreamFrame(const QuicStreamFrame& frame) {
     }
     return;
   }
-  stream->OnStreamFrame(frame);
+  stream->OnStreamFrame(frame, connection);
 }
 
 void QuicSession::OnRstStream(const QuicRstStreamFrame& frame) {
@@ -147,6 +147,12 @@ void QuicSession::OnSuccessfulVersionNegotiation(
     const QuicVersion& /*version*/) {}
 
 void QuicSession::OnPathDegrading() {}
+
+void QuicSession::StartCryptoConnect(QuicConnection* connection) {
+  DCHECK(perspective() == Perspective::IS_CLIENT);
+
+  GetCryptoStream()->CryptoConnect(connection);
+}
 
 void QuicSession::OnWindowUpdateFrame(const QuicWindowUpdateFrame& frame) {
   // Stream may be closed by the time we receive a WINDOW_UPDATE, so we can't
@@ -292,7 +298,8 @@ QuicConsumedData QuicSession::WritevData(
     QuicIOVector iov,
     QuicStreamOffset offset,
     StreamSendingState state,
-    QuicReferenceCountedPointer<QuicAckListenerInterface> ack_listener) {
+    QuicReferenceCountedPointer<QuicAckListenerInterface> ack_listener,
+    QuicConnection* connection) {
   // This check is an attempt to deal with potential memory corruption
   // in which |id| ends up set to 1 (the crypto stream id). If this happen
   // it might end up resulting in unencrypted stream data being sent.
@@ -312,7 +319,7 @@ QuicConsumedData QuicSession::WritevData(
     return QuicConsumedData(0, false);
   }
   QuicConsumedData data = connection_manager_->SendStreamData(id, iov, offset, state,
-                                                      std::move(ack_listener));
+                                                      std::move(ack_listener), connection);
   write_blocked_streams_.UpdateBytesForStream(id, data.bytes_consumed);
   return data;
 }
@@ -437,7 +444,7 @@ bool QuicSession::IsCryptoHandshakeConfirmed() const {
 }
 
 void QuicSession::OnConfigNegotiated(QuicConnection *connection) {
-  InitialConnection()->SetFromConfig(config_);
+  connection->SetFromConfig(config_);
 
   uint32_t max_streams = 0;
   if (config_.HasReceivedMaxIncomingDynamicStreams()) {

--- a/src/net/quic/core/quic_session.cc
+++ b/src/net/quic/core/quic_session.cc
@@ -151,7 +151,7 @@ void QuicSession::OnPathDegrading() {}
 void QuicSession::StartCryptoConnect(QuicConnection* connection) {
   DCHECK(perspective() == Perspective::IS_CLIENT);
 
-  GetCryptoStream()->CryptoConnect(connection);
+  GetMutableCryptoStream()->CryptoConnect(connection);
 }
 
 void QuicSession::OnWindowUpdateFrame(const QuicWindowUpdateFrame& frame) {
@@ -436,11 +436,11 @@ void QuicSession::OnFinalByteOffsetReceived(
 }
 
 bool QuicSession::IsEncryptionEstablished() const {
-  return GetCryptoStream()->encryption_established();
+  return GetCryptoStream()->encryption_established(nullptr);
 }
 
 bool QuicSession::IsCryptoHandshakeConfirmed() const {
-  return GetCryptoStream()->handshake_confirmed();
+  return GetCryptoStream()->handshake_confirmed(nullptr);
 }
 
 void QuicSession::OnConfigNegotiated(QuicConnection *connection) {
@@ -608,7 +608,6 @@ void QuicSession::OnCryptoHandshakeEvent(QuicConnection *connection, CryptoHands
       // Discard originally encrypted packets, since they can't be decrypted by
       // the peer.
       connection->NeuterUnencryptedPackets();
-      connection_manager()->OnHandshakeComplete();
       break;
 
     default:

--- a/src/net/quic/core/quic_session.h
+++ b/src/net/quic/core/quic_session.h
@@ -85,7 +85,7 @@ class QUIC_EXPORT_PRIVATE QuicSession : public QuicConnectionManagerVisitorInter
   virtual void Initialize();
 
   // QuicConnectionManagerVisitorInterface methods:
-  void OnStreamFrame(const QuicStreamFrame& frame) override;
+  void OnStreamFrame(const QuicStreamFrame& frame, QuicConnection *connection) override;
   void OnRstStream(const QuicRstStreamFrame& frame) override;
   void OnGoAway(const QuicGoAwayFrame& frame) override;
   void OnWindowUpdateFrame(const QuicWindowUpdateFrame& frame) override;
@@ -107,6 +107,7 @@ class QUIC_EXPORT_PRIVATE QuicSession : public QuicConnectionManagerVisitorInter
   bool HasPendingHandshake() const override;
   bool HasOpenDynamicStreams() const override;
   void OnPathDegrading() override;
+  void StartCryptoConnect(QuicConnection* connection) override;
 
   // Called on every incoming packet. Passes |packet| through to |connection_|.
   virtual void ProcessUdpPacket(const QuicSocketAddress& self_address,
@@ -120,13 +121,16 @@ class QUIC_EXPORT_PRIVATE QuicSession : public QuicConnectionManagerVisitorInter
   // if the socket was unexpectedly blocked.
   // If provided, |ack_notifier_delegate| will be registered to be notified when
   // we have seen ACKs for all packets resulting from this call.
+  // If the connection parameter is not the nullptr, it specifies that the
+  // data has to be sent on this connection (used for handshake messages).
   virtual QuicConsumedData WritevData(
       QuicStream* stream,
       QuicStreamId id,
       QuicIOVector iov,
       QuicStreamOffset offset,
       StreamSendingState state,
-      QuicReferenceCountedPointer<QuicAckListenerInterface> ack_listener);
+      QuicReferenceCountedPointer<QuicAckListenerInterface> ack_listener,
+      QuicConnection *connection);
 
   // Called by streams when they want to close the stream in both directions.
   virtual void SendRstStream(QuicStreamId id,

--- a/src/net/quic/core/quic_spdy_session.cc
+++ b/src/net/quic/core/quic_spdy_session.cc
@@ -465,7 +465,7 @@ size_t QuicSpdySession::WriteHeadersImpl(
   SpdySerializedFrame frame(spdy_framer_.SerializeFrame(headers_frame));
   headers_stream_->WriteOrBufferData(
       QuicStringPiece(frame.data(), frame.size()), false,
-      std::move(ack_notifier_delegate));
+      std::move(ack_notifier_delegate), nullptr);
   return frame.size();
 }
 
@@ -485,7 +485,7 @@ size_t QuicSpdySession::WritePushPromise(QuicStreamId original_stream_id,
 
   SpdySerializedFrame frame(spdy_framer_.SerializeFrame(push_promise));
   headers_stream_->WriteOrBufferData(
-      QuicStringPiece(frame.data(), frame.size()), false, nullptr);
+      QuicStringPiece(frame.data(), frame.size()), false, nullptr, nullptr);
   return frame.size();
 }
 
@@ -509,7 +509,7 @@ void QuicSpdySession::WriteDataFrame(
   // between streams.
   headers_stream_->WriteOrBufferData(
       QuicStringPiece(frame.data(), frame.size()), false,
-      std::move(force_hol_ack_listener));
+      std::move(force_hol_ack_listener), nullptr);
 }
 
 QuicConsumedData QuicSpdySession::WritevStreamData(
@@ -574,7 +574,7 @@ size_t QuicSpdySession::SendMaxHeaderListSize(size_t value) {
 
   SpdySerializedFrame frame(spdy_framer_.SerializeFrame(settings_frame));
   headers_stream_->WriteOrBufferData(
-      QuicStringPiece(frame.data(), frame.size()), false, nullptr);
+      QuicStringPiece(frame.data(), frame.size()), false, nullptr, nullptr);
   return frame.size();
 }
 
@@ -657,7 +657,7 @@ void QuicSpdySession::OnStreamFrameData(QuicStreamId stream_id,
                               QuicStringPiece(data, len));
   QUIC_DVLOG(1) << "De-encapsulating DATA frame for stream " << stream_id
                 << " offset " << offset << " len " << len << " fin " << fin;
-  OnStreamFrame(frame);
+  OnStreamFrame(frame, nullptr);
 }
 
 bool QuicSpdySession::ShouldReleaseHeadersStreamSequencerBuffer() {

--- a/src/net/quic/core/quic_spdy_stream.cc
+++ b/src/net/quic/core/quic_spdy_stream.cc
@@ -314,13 +314,15 @@ QuicConsumedData QuicSpdyStream::WritevDataInner(
     QuicIOVector iov,
     QuicStreamOffset offset,
     bool fin,
-    QuicReferenceCountedPointer<QuicAckListenerInterface> ack_listener) {
+    QuicReferenceCountedPointer<QuicAckListenerInterface> ack_listener,
+    QuicConnection* connection) {
   if (spdy_session_->headers_stream() != nullptr &&
       spdy_session_->force_hol_blocking()) {
     return spdy_session_->WritevStreamData(id(), iov, offset, fin,
                                            std::move(ack_listener));
   }
-  return QuicStream::WritevDataInner(iov, offset, fin, std::move(ack_listener));
+  return QuicStream::WritevDataInner(iov, offset, fin, std::move(ack_listener),
+      connection);
 }
 
 }  // namespace net

--- a/src/net/quic/core/quic_spdy_stream.cc
+++ b/src/net/quic/core/quic_spdy_stream.cc
@@ -62,7 +62,7 @@ void QuicSpdyStream::WriteOrBufferBody(
     const string& data,
     bool fin,
     QuicReferenceCountedPointer<QuicAckListenerInterface> ack_listener) {
-  WriteOrBufferData(data, fin, std::move(ack_listener));
+  WriteOrBufferData(data, fin, std::move(ack_listener), nullptr);
 }
 
 size_t QuicSpdyStream::WriteTrailers(
@@ -179,7 +179,7 @@ void QuicSpdyStream::OnInitialHeadersComplete(
   headers_decompressed_ = true;
   header_list_ = header_list;
   if (fin) {
-    OnStreamFrame(QuicStreamFrame(id(), fin, 0, QuicStringPiece()));
+    OnStreamFrame(QuicStreamFrame(id(), fin, 0, QuicStringPiece()), nullptr);
   }
   if (FinishedReadingHeaders()) {
     sequencer()->SetUnblocked();
@@ -229,7 +229,7 @@ void QuicSpdyStream::OnTrailingHeadersComplete(
   }
   trailers_decompressed_ = true;
   OnStreamFrame(
-      QuicStreamFrame(id(), fin, final_byte_offset, QuicStringPiece()));
+      QuicStreamFrame(id(), fin, final_byte_offset, QuicStringPiece()), nullptr);
 }
 
 void QuicSpdyStream::OnStreamReset(const QuicRstStreamFrame& frame) {

--- a/src/net/quic/core/quic_spdy_stream.h
+++ b/src/net/quic/core/quic_spdy_stream.h
@@ -192,7 +192,8 @@ class QUIC_EXPORT_PRIVATE QuicSpdyStream : public QuicStream {
       QuicIOVector iov,
       QuicStreamOffset offset,
       bool fin,
-      QuicReferenceCountedPointer<QuicAckListenerInterface> ack_listener)
+      QuicReferenceCountedPointer<QuicAckListenerInterface> ack_listener,
+      QuicConnection* connection)
       override;
 
   void set_headers_decompressed(bool val) { headers_decompressed_ = val; }

--- a/src/net/quic/core/quic_stream.h
+++ b/src/net/quic/core/quic_stream.h
@@ -51,8 +51,8 @@ class QUIC_EXPORT_PRIVATE QuicStream {
   void SetFromConfig();
 
   // Called by the session when a (potentially duplicate) stream frame has been
-  // received for this stream.
-  virtual void OnStreamFrame(const QuicStreamFrame& frame);
+  // received for this stream on a certain connection.
+  virtual void OnStreamFrame(const QuicStreamFrame& frame, QuicConnection* connection);
 
   // Called by the session when the connection becomes writeable to allow the
   // stream to write any pending data.
@@ -181,7 +181,8 @@ class QUIC_EXPORT_PRIVATE QuicStream {
   void WriteOrBufferData(
       QuicStringPiece data,
       bool fin,
-      QuicReferenceCountedPointer<QuicAckListenerInterface> ack_listener);
+      QuicReferenceCountedPointer<QuicAckListenerInterface> ack_listener,
+      QuicConnection* connection);
 
   // Adds random padding after the fin is consumed for this stream.
   void AddRandomPaddingAfterFin();
@@ -196,7 +197,8 @@ class QUIC_EXPORT_PRIVATE QuicStream {
       const struct iovec* iov,
       int iov_count,
       bool fin,
-      QuicReferenceCountedPointer<QuicAckListenerInterface> ack_listener);
+      QuicReferenceCountedPointer<QuicAckListenerInterface> ack_listener,
+      QuicConnection* connection);
 
   // Allows override of the session level writev, for the force HOL
   // blocking experiment.
@@ -204,7 +206,8 @@ class QUIC_EXPORT_PRIVATE QuicStream {
       QuicIOVector iov,
       QuicStreamOffset offset,
       bool fin,
-      QuicReferenceCountedPointer<QuicAckListenerInterface> ack_listener);
+      QuicReferenceCountedPointer<QuicAckListenerInterface> ack_listener,
+      QuicConnection* connection);
 
   // Close the write side of the socket.  Further writes will fail.
   // Can be called by the subclass or internally.
@@ -237,7 +240,8 @@ class QUIC_EXPORT_PRIVATE QuicStream {
   struct PendingData {
     PendingData(
         std::string data_in,
-        QuicReferenceCountedPointer<QuicAckListenerInterface> ack_listener);
+        QuicReferenceCountedPointer<QuicAckListenerInterface> ack_listener,
+        QuicConnection* connection);
     ~PendingData();
 
     // Pending data to be written.
@@ -247,6 +251,9 @@ class QUIC_EXPORT_PRIVATE QuicStream {
     // AckListener that should be notified when the pending data is acked.
     // Can be nullptr.
     QuicReferenceCountedPointer<QuicAckListenerInterface> ack_listener;
+    // The connection on which the data should be sent.
+    // Can be nullptr.
+    QuicConnection* connection;
   };
 
   // Calls MaybeSendBlocked on the stream's flow controller and the connection

--- a/src/net/quic/core/quic_stream_sequencer.cc
+++ b/src/net/quic/core/quic_stream_sequencer.cc
@@ -52,7 +52,7 @@ void QuicStreamSequencer::OnStreamFrame(const QuicStreamFrame& frame,
   string error_details;
   QuicErrorCode result = buffered_frames_.OnStreamData(
       byte_offset, QuicStringPiece(frame.data_buffer, frame.data_length),
-      clock_->ApproximateNow(), &bytes_written, &error_details);
+      clock_->ApproximateNow(), &bytes_written, &error_details, connection);
   if (result != QUIC_NO_ERROR) {
     string details = QuicStrCat(
         "Stream ", stream_->id(), ": ", QuicErrorCodeToString(result), ": ",

--- a/src/net/quic/core/quic_stream_sequencer.cc
+++ b/src/net/quic/core/quic_stream_sequencer.cc
@@ -36,7 +36,8 @@ QuicStreamSequencer::QuicStreamSequencer(QuicStream* quic_stream,
 
 QuicStreamSequencer::~QuicStreamSequencer() {}
 
-void QuicStreamSequencer::OnStreamFrame(const QuicStreamFrame& frame) {
+void QuicStreamSequencer::OnStreamFrame(const QuicStreamFrame& frame,
+                                        QuicConnection* connection) {
   ++num_frames_received_;
   const QuicStreamOffset byte_offset = frame.offset;
   const size_t data_len = frame.data_length;
@@ -116,6 +117,11 @@ bool QuicStreamSequencer::MaybeCloseStream() {
   }
   buffered_frames_.Clear();
   return true;
+}
+
+int QuicStreamSequencer::GetReadableRegion(iovec* iov, QuicStreamSequencerBuffer::FrameInfo *fi) const {
+  DCHECK(!blocked_);
+  return buffered_frames_.GetReadableRegion(iov, fi);
 }
 
 int QuicStreamSequencer::GetReadableRegions(iovec* iov, size_t iov_len) const {

--- a/src/net/quic/core/quic_stream_sequencer.h
+++ b/src/net/quic/core/quic_stream_sequencer.h
@@ -34,7 +34,9 @@ class QUIC_EXPORT_PRIVATE QuicStreamSequencer {
   // data is processed or the stream fails to consume data.  Any unconsumed
   // data will be buffered. If the frame is not the next in line, it will be
   // buffered.
-  void OnStreamFrame(const QuicStreamFrame& frame);
+  void OnStreamFrame(const QuicStreamFrame& frame, QuicConnection* connection);
+
+  int GetReadableRegion(iovec* iov, QuicStreamSequencerBuffer::FrameInfo* fi) const;
 
   // Once data is buffered, it's up to the stream to read it when the stream
   // can handle more data.  The following three functions make that possible.

--- a/src/net/quic/core/quic_stream_sequencer_buffer.cc
+++ b/src/net/quic/core/quic_stream_sequencer_buffer.cc
@@ -85,7 +85,8 @@ QuicErrorCode QuicStreamSequencerBuffer::OnStreamData(
     QuicStringPiece data,
     QuicTime timestamp,
     size_t* const bytes_buffered,
-    std::string* error_details) {
+    std::string* error_details,
+    QuicConnection* connection) {
   CHECK_EQ(destruction_indicator_, 123456) << "This object has been destructed";
   *bytes_buffered = 0;
   QuicStreamOffset offset = starting_offset;
@@ -226,7 +227,7 @@ QuicErrorCode QuicStreamSequencerBuffer::OnStreamData(
   UpdateGapList(current_gap, starting_offset, total_written);
 
   frame_arrival_time_map_.insert(
-      std::make_pair(starting_offset, FrameInfo(size, timestamp)));
+      std::make_pair(starting_offset, FrameInfo(size, timestamp, connection)));
   num_bytes_buffered_ += total_written;
   return QUIC_NO_ERROR;
 }
@@ -322,6 +323,14 @@ QuicErrorCode QuicStreamSequencerBuffer::Readv(const iovec* dest_iov,
     UpdateFrameArrivalMap(total_bytes_read_);
   }
   return QUIC_NO_ERROR;
+}
+
+int QuicStreamSequencerBuffer::GetReadableRegion(struct iovec* iov, QuicStreamSequencerBuffer::FrameInfo* fi) const {
+  if(frame_arrival_time_map_.find(total_bytes_read_) != frame_arrival_time_map_.end()) {
+    *fi = frame_arrival_time_map_[total_bytes_read_];
+  }
+  int iov_used = GetReadableRegions(iov, 1);
+  return iov_used;
 }
 
 int QuicStreamSequencerBuffer::GetReadableRegions(struct iovec* iov,

--- a/src/net/quic/core/quic_stream_sequencer_buffer.h
+++ b/src/net/quic/core/quic_stream_sequencer_buffer.h
@@ -71,6 +71,8 @@
 
 namespace net {
 
+class QuicConnection;
+
 namespace test {
 class QuicStreamSequencerBufferPeer;
 }  // namespace test

--- a/src/net/quic/core/quic_stream_sequencer_buffer.h
+++ b/src/net/quic/core/quic_stream_sequencer_buffer.h
@@ -88,10 +88,11 @@ class QUIC_EXPORT_PRIVATE QuicStreamSequencerBuffer {
   // A FrameInfo stores the length of a frame and the time it arrived.
   struct QUIC_EXPORT_PRIVATE FrameInfo {
     FrameInfo();
-    FrameInfo(size_t length, QuicTime timestamp);
+    FrameInfo(size_t length, QuicTime timestamp, QuicConnection *connection);
 
     size_t length;
     QuicTime timestamp;
+    QuicConnection *connection;
   };
 
   // Size of blocks used by this buffer.
@@ -121,7 +122,8 @@ class QUIC_EXPORT_PRIVATE QuicStreamSequencerBuffer {
                              QuicStringPiece data,
                              QuicTime timestamp,
                              size_t* bytes_buffered,
-                             std::string* error_details);
+                             std::string* error_details,
+                             QuicConnection* connection);
 
   // Reads from this buffer into given iovec array, up to number of iov_len
   // iovec objects and returns the number of bytes read.
@@ -129,6 +131,8 @@ class QUIC_EXPORT_PRIVATE QuicStreamSequencerBuffer {
                       size_t dest_count,
                       size_t* bytes_read,
                       std::string* error_details);
+
+  int GetReadableRegion(struct iovec* iov, struct FrameInfo* fi) const;
 
   // Returns the readable region of valid data in iovec format. The readable
   // region is the buffer region where there is valid data not yet read by

--- a/src/net/tools/quic/quic_client_base.cc
+++ b/src/net/tools/quic/quic_client_base.cc
@@ -169,7 +169,7 @@ void QuicClientBase::StartConnect() {
   // session.
   set_writer(writer);
   session()->Initialize();
-  session()->CryptoConnect();
+  session()->CryptoConnect(session()->InitialConnection());
   set_connected_or_attempting_connect(true);
 }
 

--- a/src/net/tools/quic/quic_client_session.cc
+++ b/src/net/tools/quic/quic_client_session.cc
@@ -84,9 +84,9 @@ const QuicCryptoClientStreamBase* QuicClientSession::GetCryptoStream() const {
   return crypto_stream_.get();
 }
 
-void QuicClientSession::CryptoConnect() {
+void QuicClientSession::CryptoConnect(QuicConnection* connection) {
   DCHECK(flow_controller());
-  crypto_stream_->CryptoConnect();
+  crypto_stream_->CryptoConnect(connection);
 }
 
 int QuicClientSession::GetNumSentClientHellos() const {

--- a/src/net/tools/quic/quic_client_session.cc
+++ b/src/net/tools/quic/quic_client_session.cc
@@ -43,7 +43,7 @@ void QuicClientSession::OnProofVerifyDetailsAvailable(
 
 bool QuicClientSession::ShouldCreateOutgoingDynamicStream() {
   DCHECK(!FLAGS_quic_reloadable_flag_quic_refactor_stream_creation);
-  if (!crypto_stream_->encryption_established()) {
+  if (!crypto_stream_->encryption_established(nullptr)) {
     QUIC_DLOG(INFO) << "Encryption not active so no outgoing stream created.";
     return false;
   }

--- a/src/net/tools/quic/quic_client_session.h
+++ b/src/net/tools/quic/quic_client_session.h
@@ -50,7 +50,7 @@ class QuicClientSession : public QuicClientSessionBase {
       const ProofVerifyDetails& verify_details) override;
 
   // Performs a crypto handshake with the server.
-  virtual void CryptoConnect();
+  virtual void CryptoConnect(QuicConnection* connection);
 
   // Returns the number of client hello messages that have been sent on the
   // crypto stream. If the handshake has completed then this is one greater

--- a/src/net/tools/quic/quic_multipath_client_bin.cc
+++ b/src/net/tools/quic/quic_multipath_client_bin.cc
@@ -385,8 +385,8 @@ int main(int argc, char* argv[]) {
 
   cout << "++++++++++ Adding new subflow:" << endl;
   client.AddSubflow();
-  client.AddSubflow();
-  client.UseSubflowId(3);
+  //client.AddSubflow();
+  //client.UseSubflowId(3);
 
   cout << "++++++++++ Request site #1" << endl;
   RequestSite(client, header_block, body);

--- a/src/net/tools/quic/quic_simple_server_session.cc
+++ b/src/net/tools/quic/quic_simple_server_session.cc
@@ -55,7 +55,8 @@ void QuicSimpleServerSession::StreamDraining(QuicStreamId id) {
   }
 }
 
-void QuicSimpleServerSession::OnStreamFrame(const QuicStreamFrame& frame) {
+void QuicSimpleServerSession::OnStreamFrame(const QuicStreamFrame& frame,
+    QuicConnection* connection) {
   if (!IsIncomingStream(frame.stream_id)) {
     QUIC_LOG(WARNING) << "Client shouldn't send data on server push stream";
     CloseConnection(
@@ -63,7 +64,7 @@ void QuicSimpleServerSession::OnStreamFrame(const QuicStreamFrame& frame) {
         ConnectionCloseBehavior::SEND_CONNECTION_CLOSE_PACKET);
     return;
   }
-  QuicSpdySession::OnStreamFrame(frame);
+  QuicSpdySession::OnStreamFrame(frame, connection);
 }
 
 void QuicSimpleServerSession::PromisePushResources(

--- a/src/net/tools/quic/quic_simple_server_session.h
+++ b/src/net/tools/quic/quic_simple_server_session.h
@@ -68,7 +68,7 @@ class QuicSimpleServerSession : public QuicServerSessionBase {
   void StreamDraining(QuicStreamId id) override;
 
   // Override base class to detact client sending data on server push stream.
-  void OnStreamFrame(const QuicStreamFrame& frame) override;
+  void OnStreamFrame(const QuicStreamFrame& frame, QuicConnection* connection) override;
 
   // Send out PUSH_PROMISE for all |resources| promised stream id in each frame
   // will increase by 2 for each item in |resources|.

--- a/src/net/tools/quic/quic_simple_server_stream.cc
+++ b/src/net/tools/quic/quic_simple_server_stream.cc
@@ -246,7 +246,7 @@ void QuicSimpleServerStream::SendHeadersAndBodyAndTrailers(
   QUIC_DLOG(INFO) << "Stream " << id() << " writing body (fin = " << send_fin
                   << ") with size: " << body.size();
   if (!body.empty() || send_fin) {
-    WriteOrBufferData(body, send_fin, nullptr);
+    WriteOrBufferData(body, send_fin, nullptr, nullptr);
   }
   if (send_fin) {
     // Nothing else to send.

--- a/src/net/tools/quic/quic_spdy_client_stream.cc
+++ b/src/net/tools/quic/quic_spdy_client_stream.cc
@@ -140,7 +140,7 @@ size_t QuicSpdyClientStream::SendRequest(SpdyHeaderBlock headers,
   bytes_sent += header_bytes_written_;
 
   if (!body.empty()) {
-    WriteOrBufferData(body, fin, nullptr);
+    WriteOrBufferData(body, fin, nullptr, nullptr);
   }
 
   return bytes_sent;


### PR DESCRIPTION
Added support for separate encryption/decryption contexts for each subflow.
A subflow can now be opened similar to opening a new connection (e.g. using a 0-RTT request).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jpcsmith/proto-quic/4)
<!-- Reviewable:end -->
